### PR TITLE
refactor argument handling

### DIFF
--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -13,10 +13,10 @@ module ArcAPI =
 
     // TODO TO-DO TO DO: make use of args
     /// Initializes the arc specific folder structure
-    let init (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    let init (arcConfiguration:ArcConfiguration) (arcArgs : Map<string,Argument>) =
 
         ArcConfiguration.getRootFolderPaths arcConfiguration
         |> Array.iter (Directory.CreateDirectory >> ignore)
 
     /// Returns true if called anywhere in an arc 
-    let isArc (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let isArc (arcConfiguration:ArcConfiguration) (arcArgs : Map<string,Argument>) = raise (NotImplementedException())

--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -11,9 +11,9 @@ open ISA.DataModel.InvestigationFile
 module AssayAPI =        
 
     /// Initializes a new empty assay file and associated folder structure in the arc.
-    let init (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    let init (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
-        let name = cliArgs.["AssayIdentifier"]
+        let name = getFieldValueByName "AssayIdentifier" assayArgs
 
         IsaModelConfiguration.tryGetAssayFilePath name arcConfiguration
         |> Option.get
@@ -29,10 +29,10 @@ module AssayAPI =
 
 
     /// Updates an existing assay file in the arc with the given assay metadata contained in cliArgs.
-    let update (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    let update (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
-        let assay = isaItemOfParameters (Assay(fileName = cliArgs.["AssayIdentifier"])) cliArgs
-        let studyIdentifier = cliArgs.["StudyIdentifier"]
+        let assay = isaItemOfArguments (Assay(fileName = getFieldValueByName "AssayIdentifier" assayArgs)) assayArgs
+        let studyIdentifier = getFieldValueByName "StudyIdentifier" assayArgs
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
         
@@ -41,15 +41,15 @@ module AssayAPI =
         doc.Save()
         doc.Close()
     
-    /// Opens an existing assay file in the arc with the text editor set in globalArgs, additionally setting the given assay metadata contained in cliArgs.
-    let edit (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    /// Opens an existing assay file in the arc with the text editor set in globalArgs, additionally setting the given assay metadata contained in assayArgs.
+    let edit (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
         printf "Start assay edit"
         let editor = GeneralConfiguration.getEditor arcConfiguration
         let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
 
-        let assay = isaItemOfParameters (Assay(fileName = cliArgs.["AssayIdentifier"])) cliArgs
-        let studyIdentifier = cliArgs.["StudyIdentifier"]
+        let assay = isaItemOfArguments (Assay(fileName = getFieldValueByName "AssayIdentifier" assayArgs)) assayArgs
+        let studyIdentifier = getFieldValueByName "StudyIdentifier" assayArgs
         
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
 
@@ -65,11 +65,11 @@ module AssayAPI =
         doc.Save()
         doc.Close()
     
-    /// Registers an existing assay in the arc's investigation file with the given assay metadata contained in cliArgs.
-    let register (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    /// Registers an existing assay in the arc's investigation file with the given assay metadata contained in assayArgs.
+    let register (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
-        let assay = isaItemOfParameters (Assay(fileName = cliArgs.["AssayIdentifier"])) cliArgs
-        let studyIdentifier = cliArgs.["StudyIdentifier"]
+        let assay = isaItemOfArguments (Assay(fileName = getFieldValueByName "AssayIdentifier" assayArgs)) assayArgs
+        let studyIdentifier = getFieldValueByName "StudyIdentifier" assayArgs
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
         let doc = FSharpSpreadsheetML.Spreadsheet.fromFile investigationFilePath true
@@ -81,13 +81,12 @@ module AssayAPI =
         doc.Save()
         doc.Close()
     
-    /// Creates a new assay file and associated folder structure in the arc and registers it in the arc's investigation file with the given assay metadata contained in cliArgs.
-    let add (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    /// Creates a new assay file and associated folder structure in the arc and registers it in the arc's investigation file with the given assay metadata contained in assayArgs.
+    let add (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
-        let name = cliArgs.["AssayIdentifier"]
-
-        let assay = isaItemOfParameters (Assay(fileName = name)) cliArgs
-        let studyIdentifier = cliArgs.["StudyIdentifier"]
+        let assay = isaItemOfArguments (Assay(fileName = getFieldValueByName "AssayIdentifier" assayArgs)) assayArgs
+        let studyIdentifier = getFieldValueByName "StudyIdentifier" assayArgs
+        let name = assay.FileName
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
 
@@ -112,12 +111,11 @@ module AssayAPI =
         doc.Close()
     
     /// Removes an assay file from the arc's investigation file assay register
-    let remove (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    let remove (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
-        let name = cliArgs.["AssayIdentifier"]
-
-        let assay = isaItemOfParameters (Assay(fileName = name)) cliArgs
-        let studyIdentifier = cliArgs.["StudyIdentifier"]
+        let assay = isaItemOfArguments (Assay(fileName = getFieldValueByName "AssayIdentifier" assayArgs)) assayArgs
+        let studyIdentifier = getFieldValueByName "StudyIdentifier" assayArgs
+        let name = assay.FileName
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
         
@@ -130,12 +128,12 @@ module AssayAPI =
         doc.Save()
         doc.Close()
     
-    /// Moves an assay file from one study group to another (provided by cliArgs)
-    let move (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    /// Moves an assay file from one study group to another (provided by assayArgs)
+    let move (arcConfiguration:ArcConfiguration) (assayArgs : Map<string,Argument>) =
 
-        let assay = isaItemOfParameters (Assay(fileName = cliArgs.["AssayIdentifier"])) cliArgs
-        let studyIdentifier = cliArgs.["StudyIdentifier"]
-        let targetStudy = cliArgs.["TargetStudyIdentifier"]
+        let assay = isaItemOfArguments (Assay(fileName = getFieldValueByName "AssayIdentifier" assayArgs)) assayArgs
+        let studyIdentifier = getFieldValueByName "StudyIdentifier" assayArgs
+        let targetStudy = getFieldValueByName "TargetStudyIdentifier" assayArgs
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
         

--- a/src/ArcCommander/APIs/InvestigationAPI.fs
+++ b/src/ArcCommander/APIs/InvestigationAPI.fs
@@ -10,9 +10,9 @@ open ISA.DataModel.InvestigationFile
 module InvestigationAPI =
 
     /// Creates an investigation file in the arc from the given investigation metadata contained in cliArgs that contains no studies or assays.
-    let create (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    let create (arcConfiguration:ArcConfiguration) (investigationArgs : Map<string,Argument>) =
            
-        let investigation = isaItemOfParameters (InvestigationItem()) cliArgs
+        let investigation = isaItemOfArguments (InvestigationItem()) investigationArgs
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
                   
@@ -20,10 +20,10 @@ module InvestigationAPI =
         |> ISA_XLSX.IO.ISA_Investigation.createEmpty investigationFilePath 
 
     /// [Not Implemented] Updates the existing investigation file in the arc with the given investigation metadata contained in cliArgs.
-    let update (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let update (arcConfiguration:ArcConfiguration) (investigationArgs : Map<string,Argument>) = raise (NotImplementedException())
        
     /// [Not Implemented] Opens the existing investigation file in the arc with the text editor set in globalArgs, additionally setting the given investigation metadata contained in cliArgs.
-    let edit (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let edit (arcConfiguration:ArcConfiguration) (investigationArgs : Map<string,Argument>) = raise (NotImplementedException())
        
     /// [Not Implemented] Deletes the existing investigation file in the arc
-    let delete (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let delete (arcConfiguration:ArcConfiguration) (investigationArgs : Map<string,Argument>) = raise (NotImplementedException())

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -10,18 +10,18 @@ open ISA.DataModel.InvestigationFile
 module StudyAPI =
 
     /// [Not Implemented] Initializes a new empty study file in the arc.
-    let init (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let init (arcConfiguration:ArcConfiguration) (studyArgs : Map<string,Argument>) = raise (NotImplementedException())
     
     /// [Not Implemented] Updates an existing study file in the arc with the given study metadata contained in cliArgs.
-    let update (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let update (arcConfiguration:ArcConfiguration) (studyArgs : Map<string,Argument>) = raise (NotImplementedException())
     
     /// [Not Implemented] Opens an existing study file in the arc with the text editor set in globalArgs, additionally setting the given study metadata contained in cliArgs.
-    let edit (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let edit (arcConfiguration:ArcConfiguration) (studyArgs : Map<string,Argument>) = raise (NotImplementedException())
     
     /// Registers an existing study in the arc's investigation file with the given study metadata contained in cliArgs.
-    let register (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) =
+    let register (arcConfiguration:ArcConfiguration) (studyArgs : Map<string,Argument>) =
 
-        let study = isaItemOfParameters (StudyItem()) cliArgs
+        let study = isaItemOfArguments (StudyItem()) studyArgs
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get          
         
@@ -34,10 +34,10 @@ module StudyAPI =
         doc.Close()
 
     /// [Not Implemented] Creates a new study file in the arc and registers it in the arc's investigation file with the given study metadata contained in cliArgs.
-    let add (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let add (arcConfiguration:ArcConfiguration) (studyArgs : Map<string,Argument>) = raise (NotImplementedException())
     
     /// [Not Implemented] Removes a study file from the arc's investigation file study register
-    let remove (arcConfiguration:ArcConfiguration) (cliArgs : Map<string,string>) = raise (NotImplementedException())
+    let remove (arcConfiguration:ArcConfiguration) (studyArgs : Map<string,Argument>) = raise (NotImplementedException())
 
     /// Lists all study identifiers registered in this arc's investigation file
     let list (arcConfiguration:ArcConfiguration) =

--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -10,9 +10,36 @@ open System.Diagnostics
 open ISA.DataModel
 
 open Argu
-open Argu.ArguAttributes
 
 module ArgumentProcessing = 
+
+    type Argument =
+        | Field of string
+        | Flag of bool
+
+    type AnnotatedArgument = 
+        {
+            Arg : Argument
+            Tooltip : string
+            IsMandatory : bool
+        }
+
+    let createAnnotatedArgument arg tt mand = 
+        {
+            Arg = arg
+            Tooltip = tt 
+            IsMandatory = mand
+        }
+
+    let containsFlag k (arguments : Map<string,Argument>)=
+        match Map.find k arguments with
+        | Flag b -> b
+        | Field _ -> failwithf "Argument %s is not a flag, but a field" k
+
+    let getFieldValueByName k (arguments : Map<string,Argument>) = 
+        match Map.find k arguments with
+        | Field v -> v
+        | Flag _ -> failwithf "Argument %s is not a flag, but a field" k
 
     /// For a given discriminated union value, returns the field name and the value
     let private splitUnion (x:'a) = 
@@ -33,40 +60,51 @@ module ArgumentProcessing =
         | _ -> true
    
     /// Returns true, if a value in the array contains the Mandatory attribute, but is empty
-    let private missingMandatoryAttribute (parameters : 'T []) =
-        parameters
-
-        |> Seq.exists (fun p ->
-            let unionCaseInfo,s = FSharpValue.GetUnionFields(p,typeof<'T>)
-            containsCustomAttribute<MandatoryAttribute> unionCaseInfo
-            &&
-            s = [|box ""|]
+    let private isMissingMandatoryAttribute (arguments:(string*AnnotatedArgument) []) =
+        arguments
+        |> Seq.exists (fun (k,v) ->
+            match v.Arg with
+            | Field s -> s = "" && v.IsMandatory
+            | _ -> false
         )
 
     /// Adds all union cases of 'T which are missing to the list
-    let groupArguments (args : 'T list) =
-        if typeof<'T>.Name = "EmptyArgs" then 
-            [||]
-        else
-            let m = 
-                args 
-                |> List.map splitUnion
-                |> Map.ofList
-            FSharpType.GetUnionCases(typeof<'T>)
-            |> Array.map (fun unionCase ->      
-                let v = 
+    let groupArguments (args : 'T list when 'T :> IArgParserTemplate) =
+        let m = 
+            args 
+            |> List.map splitUnion
+            |> Map.ofList
+        FSharpType.GetUnionCases(typeof<'T>)
+        |> Array.map (fun unionCase ->
+            let isMandatory = containsCustomAttribute<MandatoryAttribute>(unionCase) 
+            let fields = unionCase.GetFields()
+            match fields with 
+            | [||] -> 
+                let toolTip = (FSharpValue.MakeUnion (unionCase,[||]) :?> 'T).Usage
+                let value = Flag (Map.containsKey unionCase.Name m)              
+                unionCase.Name,createAnnotatedArgument value toolTip isMandatory
+            | [|c|] when c.PropertyType.Name = "String" -> 
+                let toolTip = (FSharpValue.MakeUnion (unionCase,[|box ""|]) :?> 'T).Usage
+                let value = 
                     match Map.tryFind unionCase.Name m with
-                    | Some value -> value
-                    | None -> [|box ""|]
-                FSharpValue.MakeUnion (unionCase,v) :?> 'T
-            )
+                    | Some value -> string value.[0]
+                    | None -> ""
+                    |> Field
+                unionCase.Name,createAnnotatedArgument value toolTip isMandatory
+            | _ ->
+                failwithf "Cannot parse argument %s because its parsing rules were not yet implemented" unionCase.Name
+        )
 
     /// Creates an isa item used in the investigation file
-    let isaItemOfParameters (item:#InvestigationFile.ISAItem) (parameters : Map<string,string>) = 
+    let isaItemOfArguments (item:#InvestigationFile.ISAItem) (parameters : Map<string,Argument>) = 
         parameters
-        |> Seq.iter (fun kv -> 
-            InvestigationFile.setKeyValue kv item
-            |> ignore
+        |> Map.iter (fun k v -> 
+            match v with
+            | Field s -> 
+                InvestigationFile.setKeyValue (System.Collections.Generic.KeyValuePair(k,s)) item
+                |> ignore
+            | Flag b ->
+                ()
         )
         item
 
@@ -113,25 +151,23 @@ module ArgumentProcessing =
             r.ReadToEnd()
     
 
-        /// Serializes simple disriminated unions in yaml format (key:value)
+        /// Serializes annotated argument in yaml format (key:value)
         ///
         /// For each value, a comment is created and put above the line using the given commentF function
-        let private serializeUnion (commentF : 'T -> string) (vs:'T []) =
-            vs
-            |> Array.map (fun v -> 
-                let comment = commentF v
-                let key,value = unionToString v
+        let private serializeAnnotatedArguments (arguments:(string*AnnotatedArgument) []) =
+            arguments
+            |> Array.map (fun (key,arg) -> 
+                let comment = 
+                    if arg.IsMandatory then
+                        sprintf "Mandatory: %s" arg.Tooltip
+                    else sprintf "%s" arg.Tooltip
+                let value = 
+                    match arg.Arg with
+                    | Flag _ -> "false"
+                    | Field v -> v
                 sprintf "#%s\n%s:%s" comment key value
             )
             |> Array.reduce (fun a b -> a + "\n" + b)
-
-        /// Serializes map in yaml format (key:value)
-        let private serializeMap (vs:Map<string,string>) =
-            vs
-            |> Seq.map (fun kv -> 
-                sprintf "%s:%s" kv.Key kv.Value
-            )
-            |> Seq.reduce (fun a b -> a + "\n" + b)
     
         /// Splits the string at the first occurence of the char 
         let private splitAtFirst (c:char) (s:string) =
@@ -143,17 +179,16 @@ module ArgumentProcessing =
                 else
                     a.[1]
 
-        /// Deserializes yaml format (key:value) to map
-        let private deserializeMap (s:string) =
+        /// Deserializes yaml format (key:value) arguments
+        let private deserializeArguments (s:string) =
             s.Split '\n'
             |> Array.choose (fun x -> 
                 if x.StartsWith "#" then
                     None
                 else 
                     splitAtFirst ':' x                
-                    |> Some
+                    |> fun (k,v) -> Some (k, Field v)
             )
-            |> Map.ofArray
 
         /// Opens a textprompt containing the result of the serializeF to the user. Returns the deserialized user input
         let createQuery editorPath arcPath serializeF deserializeF inp =
@@ -174,27 +209,25 @@ module ArgumentProcessing =
                 failwithf "could not parse query: %s" err.Message
 
         /// Opens a textprompt containing the result of the serialized input parameters. Returns the deserialized user input
-        let createParameterQuery editorPath arcPath (parameters : 'T []) = 
-         
-            let commentF (v : 'T when 'T :> IArgParserTemplate) =
-                if FSharpValue.GetUnionFields(v,typeof<'T>) |> fst |> containsCustomAttribute<MandatoryAttribute> then
-                    sprintf "Mandatory: %s" v.Usage
-                else
-                    v.Usage
-
-            parameters
-            |> createQuery editorPath arcPath (serializeUnion commentF) deserializeMap 
+        let createArgumentQuery editorPath arcPath (arguments:(string*AnnotatedArgument) []) = 
+            let flags = arguments |> Array.choose (fun (k,v) -> match v.Arg with | Flag b -> Some (k,Flag b) | _ -> None) 
+            let fields = 
+                arguments 
+                |> Array.choose (fun (k,v) -> match v.Arg with | Field b -> Some (k,v) | _ -> None) 
+                |> createQuery editorPath arcPath serializeAnnotatedArguments deserializeArguments 
+            Array.append flags fields
+            |> Map.ofArray
 
         /// If parameters are missing a mandatory field, opens a textprompt containing the result of the serialized input parameters. Returns the deserialized user input
-        let createParameterQueryIfNecessary editorPath arcPath (parameters : 'T []) = 
-            if missingMandatoryAttribute parameters then
-                createParameterQuery editorPath arcPath parameters
+        let createArgumentQueryIfNecessary editorPath arcPath (arguments:(string*AnnotatedArgument) []) = 
+            if isMissingMandatoryAttribute arguments then
+                createArgumentQuery editorPath arcPath arguments
             else 
-                parameters
-                |> Array.map unionToString
+                arguments
+                |> Array.map (fun (k,v) -> k,v.Arg)
                 |> Map.ofArray
 
-        // opens a textprompt containing the result of the serialized input item. Returns the deserialized user input
+        /// Open a textprompt containing the serialized input item. Returns item updated with the deserialized user input
         let createItemQuery editorPath arcPath (item : #InvestigationFile.ISAItem) = 
             let serializeF inp = 
                 InvestigationFile.getKeyValues inp
@@ -203,16 +236,11 @@ module ArgumentProcessing =
             let deserializeF (s:string) =
                 s.Split '\n'
                 |> Array.iter (fun x ->                 
-                    x.Split ':'
-                    |> fun a -> System.Collections.Generic.KeyValuePair(a.[0],a.[1])
+                    splitAtFirst ':' x
+                    |> System.Collections.Generic.KeyValuePair
                     |> fun kv -> InvestigationFile.setKeyValue kv item
                     |> ignore
                 )
 
                 item
             createQuery editorPath arcPath serializeF deserializeF item
-
-
-
-
-        

--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -11,12 +11,15 @@ open ISA.DataModel
 
 open Argu
 
+
 module ArgumentProcessing = 
 
+    /// Carries the argument value to the ArcCommander API functions, use 'containsFlag' and 'getFieldValuByName' to access the value
     type Argument =
         | Field of string
         | Flag of bool
 
+    /// Argument with additional information
     type AnnotatedArgument = 
         {
             Arg : Argument
@@ -24,6 +27,7 @@ module ArgumentProcessing =
             IsMandatory : bool
         }
 
+    
     let createAnnotatedArgument arg tt mand = 
         {
             Arg = arg
@@ -31,15 +35,17 @@ module ArgumentProcessing =
             IsMandatory = mand
         }
 
+    /// Returns true, if the argument flag of name k was given by the user
     let containsFlag k (arguments : Map<string,Argument>)=
         match Map.find k arguments with
-        | Flag b -> b
         | Field _ -> failwithf "Argument %s is not a flag, but a field" k
+        | Flag b -> b
 
+    /// Returns the value given by the user for name k
     let getFieldValueByName k (arguments : Map<string,Argument>) = 
         match Map.find k arguments with
         | Field v -> v
-        | Flag _ -> failwithf "Argument %s is not a flag, but a field" k
+        | Flag _ -> failwithf "Argument %s is not a field, but a flag" k
 
     /// For a given discriminated union value, returns the field name and the value
     let private splitUnion (x:'a) = 
@@ -60,7 +66,7 @@ module ArgumentProcessing =
         | _ -> true
    
     /// Returns true, if a value in the array contains the Mandatory attribute, but is empty
-    let private isMissingMandatoryAttribute (arguments:(string*AnnotatedArgument) []) =
+    let private containsMissingMandatoryAttribute (arguments:(string*AnnotatedArgument) []) =
         arguments
         |> Seq.exists (fun (k,v) ->
             match v.Arg with
@@ -220,7 +226,7 @@ module ArgumentProcessing =
 
         /// If parameters are missing a mandatory field, opens a textprompt containing the result of the serialized input parameters. Returns the deserialized user input
         let createArgumentQueryIfNecessary editorPath arcPath (arguments:(string*AnnotatedArgument) []) = 
-            if isMissingMandatoryAttribute arguments then
+            if containsMissingMandatoryAttribute arguments then
                 createArgumentQuery editorPath arcPath arguments
             else 
                 arguments

--- a/src/ArcCommander/Commands/AssayCommand.fs
+++ b/src/ArcCommander/Commands/AssayCommand.fs
@@ -6,13 +6,13 @@ open ArcCommander.CLIArguments
 /// Assay object subcommand verbs
 type AssayCommand = 
 
-    | [<CliPrefix(CliPrefix.None)>] Init     of init_args:  ParseResults<AssayInitArgs>
-    | [<CliPrefix(CliPrefix.None)>] Update   of update_args:  ParseResults<AssayUpdateArgs>
-    | [<CliPrefix(CliPrefix.None)>] Edit     of edit_args:    ParseResults<AssayEditArgs>
-    | [<CliPrefix(CliPrefix.None)>] Register of register_args:ParseResults<AssayRegisterArgs>
-    | [<CliPrefix(CliPrefix.None)>] Add      of add_args:     ParseResults<AssayAddArgs>
-    | [<CliPrefix(CliPrefix.None)>] Remove   of remove_args:  ParseResults<AssayRemoveArgs>
-    | [<CliPrefix(CliPrefix.None)>] Move     of move_args:    ParseResults<AssayMoveArguments>
+    | [<CliPrefix(CliPrefix.None)>] Init     of init_args:      ParseResults<AssayInitArgs>
+    | [<CliPrefix(CliPrefix.None)>] Update   of update_args:    ParseResults<AssayUpdateArgs>
+    | [<CliPrefix(CliPrefix.None)>] Edit     of edit_args:      ParseResults<AssayEditArgs>
+    | [<CliPrefix(CliPrefix.None)>] Register of register_args:  ParseResults<AssayRegisterArgs>
+    | [<CliPrefix(CliPrefix.None)>] Add      of add_args:       ParseResults<AssayAddArgs>
+    | [<CliPrefix(CliPrefix.None)>] Remove   of remove_args:    ParseResults<AssayRemoveArgs>
+    | [<CliPrefix(CliPrefix.None)>] Move     of move_args:      ParseResults<AssayMoveArguments>
     | [<CliPrefix(CliPrefix.None)>] [<SubCommand()>] List
 
     interface IArgParserTemplate with

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -13,17 +13,15 @@ open System.Reflection
 open FSharp.Reflection
 
 let processCommand (arcConfiguration:ArcConfiguration) commandF (r : ParseResults<'T>) =
-    //printfn "\nstart process with the global parameters: \n" 
-    //arcConfiguration |> Map.iter (printfn "\t%s:%s")
 
     let editor = GeneralConfiguration.getEditor arcConfiguration
     let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
 
     let parameterGroup =
         let g = groupArguments (r.GetAllResults())
-        Prompt.createParameterQueryIfNecessary editor workDir g  
+        Prompt.createArgumentQueryIfNecessary editor workDir g  
     printfn "\nand the parameters: \n" 
-    parameterGroup|> Map.iter (printfn "\t%s:%s")
+    parameterGroup|> Map.iter (printfn "\t%s:%O")
 
     try commandF arcConfiguration parameterGroup
     finally
@@ -38,31 +36,31 @@ let processCommandWithoutArgs (arcConfiguration:ArcConfiguration) commandF =
 
 let handleInvestigationSubCommands arcConfiguration investigationVerb =
     match investigationVerb with
-    | InvestigationCommand.Create r    -> processCommand arcConfiguration InvestigationAPI.create r
-    | InvestigationCommand.Update r    -> processCommand arcConfiguration InvestigationAPI.update r
-    | InvestigationCommand.Edit r      -> processCommand arcConfiguration InvestigationAPI.edit r
-    | InvestigationCommand.Delete r    -> processCommand arcConfiguration InvestigationAPI.delete r
+    | InvestigationCommand.Create r    -> processCommand arcConfiguration InvestigationAPI.create   r
+    | InvestigationCommand.Update r    -> processCommand arcConfiguration InvestigationAPI.update   r
+    | InvestigationCommand.Edit r      -> processCommand arcConfiguration InvestigationAPI.edit     r
+    | InvestigationCommand.Delete r    -> processCommand arcConfiguration InvestigationAPI.delete   r
 
 let handleStudySubCommands arcConfiguration studyVerb =
     match studyVerb with
-    | StudyCommand.Init r      -> processCommand arcConfiguration StudyAPI.init r
-    | StudyCommand.Update r    -> processCommand arcConfiguration StudyAPI.update r
-    | StudyCommand.Edit r      -> processCommand arcConfiguration StudyAPI.edit r
+    | StudyCommand.Init r      -> processCommand arcConfiguration StudyAPI.init     r
+    | StudyCommand.Update r    -> processCommand arcConfiguration StudyAPI.update   r
+    | StudyCommand.Edit r      -> processCommand arcConfiguration StudyAPI.edit     r
     | StudyCommand.Register r  -> processCommand arcConfiguration StudyAPI.register r
-    | StudyCommand.Add r       -> processCommand arcConfiguration StudyAPI.add r
-    | StudyCommand.Remove r    -> processCommand arcConfiguration StudyAPI.remove r
+    | StudyCommand.Add r       -> processCommand arcConfiguration StudyAPI.add      r
+    | StudyCommand.Remove r    -> processCommand arcConfiguration StudyAPI.remove   r
     | StudyCommand.List        -> processCommandWithoutArgs arcConfiguration StudyAPI.list
 
 let handleAssaySubCommands arcConfiguration assayVerb =
     match assayVerb with
-    | AssayCommand.Init r      -> processCommand arcConfiguration AssayAPI.init r
-    | AssayCommand.Update r    -> processCommand arcConfiguration AssayAPI.update r
-    | AssayCommand.Edit r      -> processCommand arcConfiguration AssayAPI.edit r
-    | AssayCommand.Register r  -> processCommand arcConfiguration AssayAPI.register r
-    | AssayCommand.Add r       -> processCommand arcConfiguration AssayAPI.add r
-    | AssayCommand.Remove r    -> processCommand arcConfiguration AssayAPI.remove r
-    | AssayCommand.Move r      -> processCommand arcConfiguration AssayAPI.move r
-    | AssayCommand.List        -> processCommandWithoutArgs arcConfiguration AssayAPI.list 
+    | AssayCommand.Init     r -> processCommand arcConfiguration AssayAPI.init     r
+    | AssayCommand.Update   r -> processCommand arcConfiguration AssayAPI.update   r
+    | AssayCommand.Edit     r -> processCommand arcConfiguration AssayAPI.edit     r
+    | AssayCommand.Register r -> processCommand arcConfiguration AssayAPI.register r
+    | AssayCommand.Add      r -> processCommand arcConfiguration AssayAPI.add      r
+    | AssayCommand.Remove   r -> processCommand arcConfiguration AssayAPI.remove   r
+    | AssayCommand.Move     r -> processCommand arcConfiguration AssayAPI.move     r
+    | AssayCommand.List       -> processCommandWithoutArgs arcConfiguration AssayAPI.list 
 
 let handleConfigurationSubCommands arcConfiguration configurationVerb =
     match configurationVerb with
@@ -72,11 +70,14 @@ let handleConfigurationSubCommands arcConfiguration configurationVerb =
 
 let handleCommand arcConfiguration command =
     match command with
-    | Investigation subCommand  -> handleInvestigationSubCommands arcConfiguration (subCommand.GetSubCommand())
-    | Study subCommand          -> handleStudySubCommands arcConfiguration (subCommand.GetSubCommand())
-    | Assay subCommand          -> handleAssaySubCommands arcConfiguration (subCommand.GetSubCommand())
-    | Configuration subcommand  -> handleConfigurationSubCommands arcConfiguration (subcommand.GetSubCommand())
-    | Init r                    -> processCommand arcConfiguration ArcAPI.init r
+    // Objects
+    | Investigation subCommand  -> handleInvestigationSubCommands   arcConfiguration (subCommand.GetSubCommand())
+    | Study subCommand          -> handleStudySubCommands           arcConfiguration (subCommand.GetSubCommand())
+    | Assay subCommand          -> handleAssaySubCommands           arcConfiguration (subCommand.GetSubCommand())
+    | Configuration subcommand  -> handleConfigurationSubCommands   arcConfiguration (subcommand.GetSubCommand())
+    // Verbs
+    | Init r                    -> processCommand   arcConfiguration ArcAPI.init r
+    // Settings
     | WorkingDir _ | Silent     -> ()
 
 [<EntryPoint>]


### PR DESCRIPTION
Previously input arguments were given to the ArcCommander API function as string. With this PR I refactored this to also allow flags as booleans