### PR TITLE
pack as dotnet-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,5 @@ coverage.xml
 .ionide
 tmp/watch/Dockerfile
 tmp/watch
+/pkg
+/tests/tool-tests/

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -8,9 +8,8 @@
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ArcCommander</ToolCommandName>
-    <Authors>Heinrich Lukas Weil, Kevin Schneider, Timo Muehlhaus nfdi4plants OSS contributors</Authors>
+    <Authors>Heinrich Lukas Weil, Kevin Schneider, Timo Muehlhaus, nfdi4plants OSS contributors</Authors>
     <Description>Tool to manage your ARCs</Description>
-    <Summary>Tool to manage your ARCs</Summary>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/nfdi4plants/arcCommander</PackageProjectUrl>
     <PackageTags>rdm dotnet arc</PackageTags>

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -5,6 +5,10 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>ArcCommander</ToolCommandName>
+  </PropertyGroup>   
   <ItemGroup>
     <None Include="config" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="IniData.fs" />

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -8,6 +8,16 @@
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>ArcCommander</ToolCommandName>
+    <Authors>Heinrich Lukas Weil, Kevin Schneider, Timo Muehlhaus nfdi4plants OSS contributors</Authors>
+    <Description>Tool to manage your ARCs</Description>
+    <Summary>Tool to manage your ARCs</Summary>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/nfdi4plants/arcCommander</PackageProjectUrl>
+    <PackageTags>rdm dotnet arc</PackageTags>
+    <RepositoryUrl>https://github.com/nfdi4plants/arcCommander</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <FsDocsLicenseLink>https://github.com/nfdi4plants/arcCommander/blob/developer/LICENSE</FsDocsLicenseLink>
+    <FsDocsReleaseNotesLink>https://github.com/nfdi4plants/arcCommander/blob/developer/RELEASE_NOTES.md</FsDocsReleaseNotesLink>
   </PropertyGroup>   
   <ItemGroup>
     <None Include="config" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
This PR packages the arc commander as dotnet-tool that can be installed via `dotnet tool install`. To make that possible for users the nuget package has to be released though. This is one step in the release of this tool, self contained binaries will be added later. Additionally, i added fake tasks to test the packaged tool.