### PR TITLE
set .sh eol in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto eol=lf
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
+*.sh text eol=lf


### PR DESCRIPTION
As this came up multiple times now we might want to make sure that `.sh` scripts will always be checked out with unix style eol characters. As this repo already uses `.gitattributes` i just added the respective setting.