### PR TITLE
Fixes and adjustments

### DIFF
--- a/src/ArcCommander/ArcConfiguration.fs
+++ b/src/ArcCommander/ArcConfiguration.fs
@@ -162,7 +162,7 @@ module IsaModelConfiguration =
     /// Returns the name of the studies file
     let tryGetStudiesFileName identifier (configuration:ArcConfiguration) =
         //Map.tryFind "studiesfilename" configuration.IsaModel
-        sprintf "%s.study.xlsx" identifier
+        sprintf "%s_isa.study.xlsx" identifier
         |> Some
 
     /// Returns the name of the studies file

--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -216,7 +216,9 @@ module ArgumentProcessing =
         let createQuery editorPath arcPath serializeF deserializeF inp =
             let yamlString = serializeF inp
             let hash = MD5Hash yamlString
-            let filePath = sprintf "%s/.arc/%s.yml" arcPath hash
+            let filename = sprintf "%s.yml" hash
+            let filePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(),filename)
+
     
             writeForce filePath yamlString
             try

--- a/src/ArcCommander/config_unix/config
+++ b/src/ArcCommander/config_unix/config
@@ -9,7 +9,7 @@ forceeditor=false
 investigationfilename=isa.investigation.xlsx
 studiesfilename=isa.studies.xlsx
 # assay location=folder.assay.rootfolder
-assayfilename=assay.isa.xlsx
+assayfilename=isa.assay.xlsx
 
 [assay]
 rootfolder=assays 

--- a/src/ArcCommander/config_win/config
+++ b/src/ArcCommander/config_win/config
@@ -9,7 +9,7 @@ forceeditor=false
 investigationfilename=isa.investigation.xlsx
 studiesfilename=isa.studies.xlsx
 # assay location=folder.assay.rootfolder
-assayfilename=assay.isa.xlsx
+assayfilename=isa.assay.xlsx
 
 [assay]
 rootfolder=assays 


### PR DESCRIPTION
#61: Moved the folder where editor files are placed from `.arc` to the standard `temp` folder

#56: Assay files now follow the naming scheme `isa.assay.xlsx` and studies follow the naming scheme `studyName_isa.study.xlsx`