### PR TITLE
Create default config whenever using the ArcCommander and a global config is not present

### DIFF
--- a/publishBinariesLnx.cmd
+++ b/publishBinariesLnx.cmd
@@ -1,0 +1,4 @@
+@echo off
+dotnet fake build -t publishBinariesLinux
+echo DONE!
+timeout 5 >nul

--- a/publishBinariesMac.cmd
+++ b/publishBinariesMac.cmd
@@ -1,0 +1,4 @@
+@echo off
+dotnet fake build -t publishBinariesMac
+echo DONE!
+timeout 5 >nul

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <TargetFramework>net5.0</TargetFramework>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -54,7 +54,7 @@ module IniData =
     let getGlobalConfigPath () =
         // most of this part only remains for legacy reasons. Config file should not be downloaded and placed by the user (as before) but installed by the ArcCommander itself.
         let getFolderPath specialFolder inOwnFolder inCompanyFolder = 
-            Environment.GetFolderPath specialFolder
+            Environment.GetFolderPath(specialFolder, Environment.SpecialFolderOption.DoNotVerify)
             |> fun x -> 
                 if inOwnFolder then 
                     Path.Combine(x, "ArcCommander", "config") 
@@ -85,7 +85,7 @@ module IniData =
         | x when x inDesktop        -> inDesktop
         | x when x inDesktop2       -> inDesktop2
         | x when x inCache2         -> inCache2
-        | _                         -> createDefault (); getFolderPath Environment.SpecialFolder.ApplicationData false true
+        | _                         -> createDefault (); inConfigFolder
         //| _ -> failwith "ERROR: No global config file found. Initiation of default config file not possible.\nPlease add the specific config file for your OS to your config folder."
         //Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,"config")
         //Path.Combine(System.Environment.SpecialFolder.ApplicationData |> System.Environment.GetFolderPath, "arcCommanderConfig")

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -38,6 +38,7 @@ module IniData =
     let createDefault () =
         let srcFilepath = 
             let appDir = Threading.Thread.GetDomain().BaseDirectory
+            printfn "appDir: %s" appDir
             let os = getOs ()
             let osConfFolder = 
                 match os with
@@ -45,8 +46,9 @@ module IniData =
                 | Unix      -> "config_unix"
             Path.Combine(appDir, osConfFolder, "config")
         let destDirPath = 
-            let configFolder = Environment.SpecialFolder.LocalApplicationData |> Environment.GetFolderPath
+            let configFolder = Environment.SpecialFolder.ApplicationData |> Environment.GetFolderPath
             Path.Combine(configFolder, "DataPLANT", "ArcCommander")
+        printfn "destDir: %s" destDirPath
         Directory.CreateDirectory(destDirPath) |> ignore
         let destFilepath = Path.Combine(destDirPath, "config")
         File.Copy(srcFilepath, destFilepath)
@@ -63,15 +65,15 @@ module IniData =
                     Path.Combine(x, "DataPLANT", "ArcCommander", "config")
                 else 
                     Path.Combine(x, "config")
-        let inConfigFolder  = getFolderPath Environment.SpecialFolder.LocalApplicationData  false   true
-        let inConfigFolder2 = getFolderPath Environment.SpecialFolder.LocalApplicationData  true   false
-        let inConfigFolder3 = getFolderPath Environment.SpecialFolder.LocalApplicationData  false  false
+        let inConfigFolder  = getFolderPath Environment.SpecialFolder.ApplicationData       false  true
+        let inConfigFolder2 = getFolderPath Environment.SpecialFolder.ApplicationData       true   false
+        let inConfigFolder3 = getFolderPath Environment.SpecialFolder.ApplicationData       false  false
         let inCache         = getFolderPath Environment.SpecialFolder.InternetCache         false  false
         let inCache2        = getFolderPath Environment.SpecialFolder.InternetCache         true   false
         let inDesktop       = getFolderPath Environment.SpecialFolder.DesktopDirectory      false  false
         let inDesktop2      = getFolderPath Environment.SpecialFolder.DesktopDirectory      true   false
-        let inLocal         = getFolderPath Environment.SpecialFolder.ApplicationData       true   false
-        let inLocal2        = getFolderPath Environment.SpecialFolder.ApplicationData       false  false
+        let inLocal         = getFolderPath Environment.SpecialFolder.LocalApplicationData  true   false
+        let inLocal2        = getFolderPath Environment.SpecialFolder.LocalApplicationData  false  false
         let inUser          = getFolderPath Environment.SpecialFolder.UserProfile           true   false
         let inUser2         = getFolderPath Environment.SpecialFolder.UserProfile           false  false
         match File.Exists with

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -36,19 +36,16 @@ module IniData =
 
     /// Creates a default config file in the user's config folder (AppData\Local in Windows, ~/config in Unix).
     let createDefault () =
+        let os = getOs ()
         let srcFilepath = 
             let appDir = Threading.Thread.GetDomain().BaseDirectory
-            printfn "appDir: %s" appDir
-            let os = getOs ()
             let osConfFolder = 
                 match os with
                 | Windows   -> "config_win"
                 | Unix      -> "config_unix"
             Path.Combine(appDir, osConfFolder, "config")
-        let destDirPath = 
-            let configFolder = Environment.SpecialFolder.ApplicationData |> Environment.GetFolderPath
-            Path.Combine(configFolder, "DataPLANT", "ArcCommander")
-        printfn "destDir: %s" destDirPath
+        let configFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify)
+        let destDirPath = Path.Combine(configFolder, "DataPLANT", "ArcCommander")
         Directory.CreateDirectory(destDirPath) |> ignore
         let destFilepath = Path.Combine(destDirPath, "config")
         File.Copy(srcFilepath, destFilepath)
@@ -88,7 +85,7 @@ module IniData =
         | x when x inDesktop        -> inDesktop
         | x when x inDesktop2       -> inDesktop2
         | x when x inCache2         -> inCache2
-        | _                         -> createDefault (); inConfigFolder
+        | _                         -> createDefault (); getFolderPath Environment.SpecialFolder.ApplicationData false true
         //| _ -> failwith "ERROR: No global config file found. Initiation of default config file not possible.\nPlease add the specific config file for your OS to your config folder."
         //Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,"config")
         //Path.Combine(System.Environment.SpecialFolder.ApplicationData |> System.Environment.GetFolderPath, "arcCommanderConfig")


### PR DESCRIPTION
- Before, users must download an OS-specific config file and place it into one of several folders for the ArcCommander to work
  - This was, from a user's perspective, quite troublesome and annoying
- Now the ArcCommander creates a global config file with default values in `$XDG_HOME_CONFIG` whenever the ArcCommander is used and a global config file is not present there
- Due to legacy reasons, the ArcCommander still searches for the config file in those folders from before
  - With this, individual user settings set in previous ArcCommander versions can still be applied
- Addresses #70 