### PR TITLE
Inform Users about differences between assay/study registry and files

### DIFF
--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -128,14 +128,10 @@ module ArcAPI =
         let log = Logging.createLogger "ArcExportLog"
 
         log.Info("Start Arc Export")
-    
-        let assayRootFolder = AssayConfiguration.getRootFolderPath arcConfiguration
-    
+       
         let investigationFilePath = IsaModelConfiguration.getInvestigationFilePath arcConfiguration
     
-        let assayNames = 
-            DirectoryInfo(assayRootFolder).GetDirectories()
-            |> Array.map (fun d -> d.Name)
+        let assayNames = AssayConfiguration.getAssayNames arcConfiguration
                 
         let investigation =
             try Investigation.fromFile investigationFilePath 

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -201,6 +201,20 @@ module StudyAPI =
         | Some studies -> 
             match API.Study.tryGetByIdentifier identifier studies with
             | Some study -> 
+
+                match study.Assays with
+                | None | Some [] -> ()
+                | Some assays -> 
+                    log.Warn($"WARN: Study with the identifier {identifier} still contained following assays which might remain unregistered when the study is removed: ")
+                    assays 
+                    |> List.iter (fun a -> 
+                        let identifier = 
+                            a.FileName 
+                             |> Option.bind (fun fn -> IsaModelConfiguration.tryGetAssayIdentifierOfFileName fn arcConfiguration)
+                             |> Option.get
+                        log.Warn($"WARN: Assay \"{identifier}\"")
+                    )
+                    log.Info($"You can register the assays to a different study using \"arc a register\"")
                 API.Study.removeByIdentifier identifier studies 
                 |> API.Investigation.setStudies investigation
             | None -> 

--- a/src/ArcCommander/ArcConfiguration.fs
+++ b/src/ArcCommander/ArcConfiguration.fs
@@ -173,8 +173,13 @@ module GeneralConfiguration =
 module IsaModelConfiguration =
 
     /// Returns the assayIdentifier from a filename.
-    let getAssayIdentifierOfFileName (assayFileName : string) =
-        System.IO.Path.GetFileName assayFileName
+    let tryGetAssayIdentifierOfFileName (assayFileName : string) (configuration : ArcConfiguration) =      
+        let name = Map.tryFind "assayfilename" configuration.IsaModel |> Option.get
+        match assayFileName.Replace(@"\","/").Split("/") with
+        | [|assayIdentifier; fn |] when fn = name -> Some assayIdentifier
+        | [|assayIdentifier; _ |] -> None
+        | _ -> None
+        
 
     /// Returns the relative path of the assay file if it exists. Else returns None.
     let tryGetAssayFileName assayIdentifier (configuration : ArcConfiguration) =

--- a/src/ArcCommander/ArcConfiguration.fs
+++ b/src/ArcCommander/ArcConfiguration.fs
@@ -236,6 +236,23 @@ module IsaModelConfiguration =
         tryGetStudiesFilePath identifier configuration
         |> Option.get
 
+    /// Returns the full path of the study files located in the arc root folder.
+    let findStudyFilePaths (configuration : ArcConfiguration) =
+        let workDir = Map.find "workdir" configuration.General
+        Directory.GetFiles(workDir)
+        |> Array.filter (fun s -> s.EndsWith "_isa.study.xlsx")
+
+    /// Returns the study identifiers of the study files located in the arc root folder.
+    let findStudyIdentifiers (configuration : ArcConfiguration) =
+        let workDir = Map.find "workdir" configuration.General
+        Directory.GetFiles(workDir)
+        |> Array.choose (fun s -> 
+            if s.EndsWith "_isa.study.xlsx" then
+                Some (System.IO.FileInfo(s).Name.Replace("_isa.study.xlsx",""))
+            else 
+                None
+        )
+
     /// Returns the full path of the investigation file if it exists. Else returns None.
     let tryGetInvestigationFilePath (configuration : ArcConfiguration) =
         let workDir = Map.find "workdir" configuration.General
@@ -311,4 +328,5 @@ module AssayConfiguration =
                 Path.Combine([|r; v|])
             )
         | _ -> Array.empty
+
 

--- a/tests/ArcCommander.Tests.NetCore/ArcCommander.Tests.NetCore.fsproj
+++ b/tests/ArcCommander.Tests.NetCore/ArcCommander.Tests.NetCore.fsproj
@@ -21,10 +21,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     <PackageReference Update="FSharp.Core" Version="5.0.2" />
     <PackageReference Include="Argu" Version="6.1.1" />
-    <PackageReference Include="FSharpSpreadsheetML" Version="0.0.7" />
+    <PackageReference Include="FSharpSpreadsheetML" Version="0.0.8" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="ISADotNet" Version="0.4.0-preview.3" />
-    <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.3" />
+    <PackageReference Include="ISADotNet" Version="0.4.0-preview.4" />
+    <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="ArcCommander\TestFiles\" />


### PR DESCRIPTION
In the best case, study files and assay folder in the arc should also be registered in the investigation file and vice versa. The changes made in this PR aim to inform the user about asynchronity between the two when using the `study unregister`, `study list` and `assay list` functions.

Closes #94

