### PR TITLE
Logger changes

### DIFF
--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -27,16 +27,14 @@ module ArcAPI =
     let init (arcConfiguration : ArcConfiguration) (arcArgs : Map<string,Argument>) =
 
         let log = Logging.createLogger "ArcInitLog"
-
-        let verbosity = GeneralConfiguration.getVerbosity arcConfiguration
         
         log.Info("Start Arc Init")
 
         let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
 
-        let editor =            tryGetFieldValueByName "EditorPath" arcArgs
-        let gitLFSThreshold =   tryGetFieldValueByName "GitLFSByteThreshold" arcArgs
-        let repositoryAdress =  tryGetFieldValueByName "RepositoryAdress" arcArgs 
+        let editor              = tryGetFieldValueByName "EditorPath"           arcArgs
+        let gitLFSThreshold     = tryGetFieldValueByName "GitLFSByteThreshold"  arcArgs
+        let repositoryAdress    = tryGetFieldValueByName "RepositoryAdress"     arcArgs 
 
 
         log.Trace("Create Directory")
@@ -76,7 +74,7 @@ module ArcAPI =
         with 
         | _ -> 
 
-            log.Error("ERROR: Git could not be set up. Please try installing Git cli and run `arc git init`.")
+            log.Error("Git could not be set up. Please try installing Git cli and run `arc git init`.")
 
     /// Update the investigation file with the information from the other files and folders.
     let update (arcConfiguration : ArcConfiguration) =
@@ -99,7 +97,7 @@ module ArcAPI =
             | :? FileNotFoundException -> 
                 Investigation.empty
             | err -> 
-                log.Fatal($"ERROR: {err.ToString()}")
+                log.Fatal($"{err.ToString()}")
                 raise (Exception(""))
 
         let rec updateInvestigationAssays (assayNames : string list) (investigation : Investigation) =
@@ -149,7 +147,7 @@ module ArcAPI =
             | :? FileNotFoundException -> 
                 Investigation.empty
             | err -> 
-                log.Fatal($"ERROR: {err.Message}")
+                log.Fatal($"{err.Message}")
                 raise (Exception(""))
     
         let rec updateInvestigationAssays (assayNames : string list) (investigation : Investigation) =

--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -64,7 +64,7 @@ module AssayAPI =
                 []
 
         if AssayFolder.exists arcConfiguration name then
-            log.Error($"ERROR: Assay folder with identifier {name} already exists.")
+            log.Error($"Assay folder with identifier {name} already exists.")
         else
             AssayConfiguration.getSubFolderPaths name arcConfiguration
             |> Array.iter (Directory.CreateDirectory >> ignore)
@@ -137,32 +137,32 @@ module AssayAPI =
                     else
                         let msg = $"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}."
                         if containsFlag "AddIfMissing" assayArgs then 
-                            log.Warn($"WARNING: {msg}")
+                            log.Warn($"{msg}")
                             log.Info("Registering assay as AddIfMissing Flag was set.")
                             API.Assay.add assays assay
                             |> API.Study.setAssays study
                         else 
-                            log.Error($"ERROR: {msg}")
+                            log.Error($"{msg}")
                             log.Trace("AddIfMissing argument can be used to register assay with the update command if it is missing.")
                             study
                 | None -> 
                     let msg = $"The study with the identifier {studyIdentifier} does not contain any assays."
                     if containsFlag "AddIfMissing" assayArgs then
-                        log.Warn($"WARNING: {msg}")
+                        log.Warn($"{msg}")
                         log.Info("Registering assay as AddIfMissing Flag was set.")
                         [assay]
                         |> API.Study.setAssays study
                     else 
-                        log.Error($"ERROR: {msg}")
+                        log.Error($"{msg}")
                         log.Trace("AddIfMissing argument can be used to register assay with the update command if it is missing.")
                         study
                 |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                 |> API.Investigation.setStudies investigation
             | None -> 
-                log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                 investigation
         | None -> 
-            log.Error("ERROR: The investigation does not contain any studies.")
+            log.Error("The investigation does not contain any studies.")
             investigation
         |> Investigation.toFile investigationFilePath
 
@@ -224,7 +224,7 @@ module AssayAPI =
                         | Some oldAssayInvestigationFile -> 
                             // check if assay metadata from assay file and investigation file differ
                             if compareAssayMetadata oldAssayInvestigationFile oldAssayAssayFile |> not then 
-                                log.Warn("WARNING: The assay metadata in the investigation file differs from that in the assay file.")
+                                log.Warn("The assay metadata in the investigation file differs from that in the assay file.")
                             getNewAssay oldAssayAssayFile
                             // update assay metadata in investigation file
                             |> fun a -> 
@@ -235,16 +235,16 @@ module AssayAPI =
                                 |> Investigation.toFile investigationFilePath
                                 a
                         | None -> 
-                            log.Error($"ERROR: Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}. It is advised to register the assay in the investigation file via \"arc a register\".")
+                            log.Error($"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}. It is advised to register the assay in the investigation file via \"arc a register\".")
                             getNewAssay oldAssayAssayFile
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any assays. It is advised to register the assay with the identifier {assayIdentifier} in the investigation file via \"arc a register\".")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any assays. It is advised to register the assay with the identifier {assayIdentifier} in the investigation file via \"arc a register\".")
                         getNewAssay oldAssayAssayFile
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file. It is advised to register the assay with the identifier {assayIdentifier} in the investigation file via \"arc a register\".")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file. It is advised to register the assay with the identifier {assayIdentifier} in the investigation file via \"arc a register\".")
                     getNewAssay oldAssayAssayFile
             | None -> 
-                log.Error($"ERROR: The investigation does not contain any studies. It is advised to register the assay with the identifier {assayIdentifier} in the investigation file via \"arc a register\".")
+                log.Error($"The investigation does not contain any studies. It is advised to register the assay with the identifier {assayIdentifier} in the investigation file via \"arc a register\".")
                 getNewAssay oldAssayAssayFile
 
         // part that writes assay metadata into the assay file
@@ -291,7 +291,7 @@ module AssayAPI =
                 | Some assays -> 
                     match API.Assay.tryGetByFileName assayFileName assays with
                     | Some _ ->
-                        log.Error($"ERROR: Assay with the identifier {assayIdentifier} already exists in the investigation file.")
+                        log.Error($"Assay with the identifier {assayIdentifier} already exists in the investigation file.")
                         assays
                     | None ->
                         API.Assay.add assays assay
@@ -356,16 +356,16 @@ module AssayAPI =
                         |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                         |> API.Investigation.setStudies investigation
                     | None ->
-                        log.Error($"ERROR: Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
+                        log.Error($"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any assays.")
+                    log.Error($"The study with the identifier {studyIdentifier} does not contain any assays.")
                     investigation
             | None -> 
-                log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                 investigation
         | None -> 
-            log.Error($"ERROR: The investigation does not contain any studies.")
+            log.Error($"The investigation does not contain any studies.")
             investigation
         |> Investigation.toFile investigationFilePath
     
@@ -430,16 +430,16 @@ module AssayAPI =
                             |> API.Study.add studies
                             |> API.Investigation.setStudies investigation
                     | None -> 
-                        log.Error($"ERROR: Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
+                        log.Error($"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any assays.")
+                    log.Error($"The study with the identifier {studyIdentifier} does not contain any assays.")
                     investigation
             | None -> 
-                log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                 investigation
         | None -> 
-            log.Error($"ERROR: The investigation does not contain any studies.")
+            log.Error($"The investigation does not contain any studies.")
             investigation
         |> Investigation.toFile investigationFilePath
 
@@ -477,13 +477,13 @@ module AssayAPI =
                         |> Prompt.serializeXSLXWriterOutput (Assays.toRows None)
                         |> log.Debug
                     | None -> 
-                        log.Error($"ERROR: Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
+                        log.Error($"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
                 | None -> 
-                    log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any assays.")
+                    log.Error($"The study with the identifier {studyIdentifier} does not contain any assays.")
             | None -> 
-                log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
         | None -> 
-            log.Error("ERROR: The investigation does not contain any studies.")
+            log.Error("The investigation does not contain any studies.")
 
 
 
@@ -506,14 +506,14 @@ module AssayAPI =
             |> List.choose (fun s ->
                 let studyIdentifier = 
                     if s.Identifier.IsNone then
-                        log.Warn("WARN: Study does not have identifier.")
+                        log.Warn("Study does not have identifier.")
                         ""
                     else 
                         s.Identifier.Value
                
                 match s.Assays with
                 | None | Some [] -> 
-                    log.Warn($"WARN: Study {studyIdentifier} does not contain assays.")
+                    log.Warn($"Study {studyIdentifier} does not contain assays.")
                     None
                 | Some assays ->
                     (
@@ -522,7 +522,7 @@ module AssayAPI =
                     |> List.choose (fun a ->
                         match a.FileName with
                         | None | Some "" -> 
-                            log.Warn("WARN: Assay does not have filename.")
+                            log.Warn("Assay does not have filename.")
                             None
                         | Some filename ->
                             match IsaModelConfiguration.tryGetAssayIdentifierOfFileName filename arcConfiguration with
@@ -530,7 +530,7 @@ module AssayAPI =
                                 Some identifier
 
                             | None -> 
-                                log.Error($"ERROR: Could not parse assay filename {filename} to obtain identifier. Check formatting.")
+                                log.Error($"Could not parse assay filename {filename} to obtain identifier. Check formatting.")
                                 None
                     ))
                     |> Some
@@ -545,19 +545,19 @@ module AssayAPI =
         let combined = Set.union assayIdentifiers assayFolderIdentifiers
 
         if not onlyRegistered.IsEmpty then
-            log.Warn("WARN: Arc contains following registered assays that have no associated folders:")
+            log.Warn("The ARC contains following registered assays that have no associated folders:")
             onlyRegistered
             |> Seq.iter ((sprintf "WARN: %s") >> log.Warn) 
             log.Info($"You can init the assay folder using \"arc a init\".")
 
         if not onlyInitialized.IsEmpty then
-            log.Warn("WARN: Arc contains assay folders with the following identifiers not registered in the investigation:")
+            log.Warn("The ARC contains assay folders with the following identifiers not registered in the investigation:")
             onlyInitialized
             |> Seq.iter ((sprintf "WARN: %s") >> log.Warn) 
             log.Info($"You can register the assay using \"arc a register\".")
 
         if combined.IsEmpty then
-            log.Error("ERROR: ARC does not contain any assays.")
+            log.Error("The ARC does not contain any assays.")
 
         studies
         |> List.iter (fun (studyIdentifier,assays) ->
@@ -608,16 +608,16 @@ module AssayAPI =
                         | Some assay ->
                             Some assay
                         | None -> 
-                            log.Error($"ERROR: Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
                             None
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any assays.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any assays.")
                         None
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     None
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 None
 
         let persons,assayFromFile =
@@ -628,10 +628,10 @@ module AssayAPI =
                     p, Some a
                 with
                 | err -> 
-                    log.Error(sprintf "ERROR: Assay file \"%s\" could not be read:\n %s" assayFilePath (err.ToString()))
+                    log.Error(sprintf "Assay file \"%s\" could not be read:\n %s" assayFilePath (err.ToString()))
                     [], None
             else
-                log.Error(sprintf "ERROR: Assay file \"%s\" does not exist." assayFilePath)
+                log.Error(sprintf "Assay file \"%s\" does not exist." assayFilePath)
                 [], None
         
         let mergedAssay = 
@@ -639,7 +639,7 @@ module AssayAPI =
             | Some ai, Some a -> API.Update.UpdateByExisting.updateRecordType ai a
             | None, Some a -> a
             | Some ai, None -> ai
-            | None, None -> log.Fatal("ERROR: No assay could be retrieved."); raise (Exception(""))
+            | None, None -> log.Fatal("No assay could be retrieved."); raise (Exception(""))
           
           
         if containsFlag "ProcessSequence" assayArgs then
@@ -704,16 +704,16 @@ module AssayAPI =
                                 | Some assay ->
                                     Some assay
                                 | None -> 
-                                    log.Error($"ERROR: Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
+                                    log.Error($"Assay with the identifier {assayIdentifier} does not exist in the study with the identifier {studyIdentifier}.")
                                     None
                             | None -> 
-                                log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any assays.")
+                                log.Error($"The study with the identifier {studyIdentifier} does not contain any assays.")
                                 None
                         | None -> 
-                            log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                            log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                             None
                     | None -> 
-                        log.Error("ERROR: The investigation does not contain any studies.")
+                        log.Error("The investigation does not contain any studies.")
                         None
 
                 let persons,assayFromFile =
@@ -724,10 +724,10 @@ module AssayAPI =
                             p, Some a
                         with
                         | err -> 
-                            log.Error(sprintf "ERROR: Assay file \"%s\" could not be read:\n %s" assayFilePath (err.ToString()))
+                            log.Error(sprintf "Assay file \"%s\" could not be read:\n %s" assayFilePath (err.ToString()))
                             [], None
                     else
-                        log.Error(sprintf "ERROR: Assay file \"%s\" does not exist." assayFilePath)
+                        log.Error(sprintf "Assay file \"%s\" does not exist." assayFilePath)
                         [], None
         
                 let mergedAssay = 
@@ -735,7 +735,7 @@ module AssayAPI =
                     | Some ai, Some a -> API.Update.UpdateByExisting.updateRecordType ai a
                     | None, Some a -> a
                     | Some ai, None -> ai
-                    | None, None -> log.Fatal("ERROR: No assay could be retrieved."); raise (Exception(""))
+                    | None, None -> log.Fatal("No assay could be retrieved."); raise (Exception(""))
             
                 Study.create(Contacts = persons, Assays = [mergedAssay])
             )
@@ -828,11 +828,11 @@ module AssayAPI =
                 else
                     let msg = $"Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}."
                     if containsFlag "AddIfMissing" personArgs then
-                        log.Warn($"WARNING: {msg}")
+                        log.Warn($"{msg}")
                         log.Info("Registering person as AddIfMissing Flag was set.")
                         let newPersons = API.Person.add persons person
                         MetaData.overwriteWithPersons "Investigation" newPersons doc
-                    else log.Error($"ERROR: {msg}")
+                    else log.Error($"{msg}")
 
             finally
                 Spreadsheet.close doc
@@ -870,7 +870,7 @@ module AssayAPI =
                         let newPersons = API.Person.updateBy ((=) person) API.Update.UpdateAll p persons
                         MetaData.overwriteWithPersons "Investigation" newPersons doc
                 | None ->
-                    log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}.")
+                    log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}.")
 
                 Spreadsheet.close doc
 
@@ -949,7 +949,7 @@ module AssayAPI =
                     let newPersons = API.Person.removeByFullName firstName midInitials lastName persons
                     MetaData.overwriteWithPersons "Investigation" newPersons doc
                 else
-                    log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}.")
+                    log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}.")
 
             finally
                 Spreadsheet.close doc
@@ -981,7 +981,7 @@ module AssayAPI =
                     |> Prompt.serializeXSLXWriterOutput (Contacts.toRows None)
                     |> log.Debug
                 | None ->
-                    log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}.")
+                    log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the assay with the identifier {assayIdentifier}.")
 
             finally
                 Spreadsheet.close doc

--- a/src/ArcCommander/APIs/ConfigurationAPI.fs
+++ b/src/ArcCommander/APIs/ConfigurationAPI.fs
@@ -31,7 +31,7 @@ module ConfigurationAPI =
             let iniData = 
                 match path with
                 | Some p    -> p |> IniData.fromFile
-                | None      -> log.Warn("WARNING: No config file found. Load default config instead."); ArcConfiguration.GetDefault()
+                | None      -> log.Warn("No config file found. Load default config instead."); ArcConfiguration.GetDefault()
             match path with
             | Some p ->
                 iniData
@@ -40,7 +40,7 @@ module ConfigurationAPI =
                 |> fun differences -> updateWithDifferences differences iniData
                 |> IniData.toFile p
             | None ->
-                log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+                log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
         // If only local flag is set, open prompt only with local settings and apply changes on local settings
         | false,true ->
             let path = IniData.getLocalConfigPath workdir
@@ -63,14 +63,14 @@ module ConfigurationAPI =
                 |> fun differences -> updateWithDifferences differences localIni
                 |> IniData.toFile path
             | None -> 
-                log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+                log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
         // If local and global flags are set, open prompt with merged settings and set both local and global settings files to the user input
         | true,true ->
             let globalPath = IniData.tryGetGlobalConfigPath()
             let globalIni = 
                 match globalPath with
                 | Some p    -> IniData.fromFile p
-                | None      -> log.Warn("WARNING: No config file found. Load default config instead."); ArcConfiguration.GetDefault()
+                | None      -> log.Warn("No config file found. Load default config instead."); ArcConfiguration.GetDefault()
             let localPath = IniData.getLocalConfigPath workdir
             let localIni = IniData.fromFile localPath
             let iniData = IniData.tryLoadMergedIniData workdir
@@ -85,7 +85,7 @@ module ConfigurationAPI =
                     updateWithDifferences differences localIni
                     |> IniData.toFile localPath
             | None -> 
-                log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+                log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
 
     /// Lists all current settings specified in the configuration.
     let list (arcConfiguration : ArcConfiguration) (configurationArgs : Map<string,Argument>) =
@@ -127,7 +127,7 @@ module ConfigurationAPI =
         | true,false ->
             match IniData.tryGetGlobalConfigPath () with
             | Some p    -> setValueInIniPath p
-            | None      -> log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+            | None      -> log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
         // If both global and local flags are set, the setting is set both in the local and the global config file
         | true,true ->
             let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
@@ -135,7 +135,7 @@ module ConfigurationAPI =
             |> setValueInIniPath
             match IniData.tryGetGlobalConfigPath () with
             | Some p    -> setValueInIniPath p
-            | None      -> log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+            | None      -> log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
         // If only local or no flag is set, the setting is set only in the local config file
         | false,false | false,true  -> 
             let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
@@ -160,7 +160,7 @@ module ConfigurationAPI =
         | true,false ->
             match IniData.tryGetGlobalConfigPath () with
             | Some p    -> unsetValueInIniPath p
-            | None      -> log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+            | None      -> log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
         // If both global and local flags are set, the setting is unset both in the local and the global config file
         | true,true ->
             let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
@@ -168,7 +168,7 @@ module ConfigurationAPI =
             |> unsetValueInIniPath
             match IniData.tryGetGlobalConfigPath () with
             | Some p    -> unsetValueInIniPath p
-            | None      -> log.Error("ERROR: No folder for global config file known for this environment. Config file settings cannot be saved.")
+            | None      -> log.Error("No folder for global config file known for this environment. Config file settings cannot be saved.")
         // If only local or no flag is set, the setting is set only in the local config file
         | false,false | false,true  -> 
             let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration

--- a/src/ArcCommander/APIs/ExternalExecutables.fs
+++ b/src/ArcCommander/APIs/ExternalExecutables.fs
@@ -78,7 +78,7 @@ module ExternalExecutables =
                     fun ev -> 
                         let roev = reviseOutput ev.Data
                         if matchCmdErrMsg roev || matchBashErrMsg roev then 
-                            log.Error("ERROR: No executable, command or script file with given argument name known.") 
+                            log.Error("No executable, command or script file with given argument name known.") 
                             handleExceptionMessage log e2
                             raise (Exception())
                         else checkNonLog roev (sprintf "External Tool ERROR: %s" >> log.Error)

--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -15,7 +15,7 @@ module GitAPI =
         log.Trace(sprintf "git %s" command)
         let success = Fake.Tools.Git.CommandHelper.directRunGitCommand repoDir command
         if not success
-        then log.Error("ERROR: Git command could not be run.")
+        then log.Error("Git command could not be run.")
         success
 
     /// Returns repository directory path.
@@ -151,7 +151,7 @@ module GitAPI =
                 executeGitCommand repoDir ("remote add origin " + remote) |> ignore
 
         if hasRemote() then log.Trace("Start syncing with remote" )
-        else                log.Error("ERROR: Can not sync with remote as no remote repository adress was specified.")
+        else                log.Error("Can not sync with remote as no remote repository adress was specified.")
 
         // pull if remote exists
         if hasRemote() then

--- a/src/ArcCommander/APIs/InvestigationAPI.fs
+++ b/src/ArcCommander/APIs/InvestigationAPI.fs
@@ -24,7 +24,7 @@ module InvestigationAPI =
         log.Info("Start Investigation Create")
 
         if InvestigationFile.exists arcConfiguration then
-            log.Error("ERROR: Investigation file does already exist.")
+            log.Error("Investigation file does already exist.")
 
         else 
             let investigation = 
@@ -168,23 +168,23 @@ module InvestigationAPI =
                 else
                     let msg = $"Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation."
                     if containsFlag "AddIfMissing" personArgs then
-                        log.Warn($"WARNING: {msg}")
+                        log.Warn($"{msg}")
                         log.Info("Registering person as AddIfMissing Flag was set.")
                         API.Person.add persons person
                         |> API.Investigation.setContacts investigation
                     else 
-                        log.Error($"ERROR: {msg}")
+                        log.Error($"{msg}")
                         log.Trace("AddIfMissing argument can be used to register person with the update command if it is missing.")
                         investigation
             | None -> 
                 let msg = "The investigation does not contain any persons."
                 if containsFlag "AddIfMissing" personArgs then 
-                    log.Warn($"WARNING: {msg}")
+                    log.Warn($"{msg}")
                     log.Info("Registering person as AddIfMissing Flag was set.")
                     [person]
                     |> API.Investigation.setContacts investigation
                 else 
-                    log.Error($"ERROR: {msg}")
+                    log.Error($"{msg}")
                     log.Trace("AddIfMissing argument can be used to register person with the update command if it is missing.")
                     investigation
             |> Investigation.toFile investigationFilePath
@@ -217,10 +217,10 @@ module InvestigationAPI =
                     |> fun p -> API.Person.updateBy ((=) person) API.Update.UpdateAll p persons
                     |> API.Investigation.setContacts investigation
                 | None ->
-                    log.Error($"ERRROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation.") 
+                    log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation.") 
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any persons.")
+                log.Error("The investigation does not contain any persons.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -263,7 +263,7 @@ module InvestigationAPI =
             match investigation.Contacts with
             | Some persons ->
                 if API.Person.existsByFullName firstName midInitials lastName persons then
-                    log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} already exists in the investigation file.")
+                    log.Error($"Person with the name {firstName} {midInitials} {lastName} already exists in the investigation file.")
                     persons
                 else
                     API.Person.add persons person
@@ -292,10 +292,10 @@ module InvestigationAPI =
                     API.Person.removeByFullName firstName midInitials lastName persons
                     |> API.Investigation.setContacts investigation
                 else
-                    log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation file")
+                    log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation file")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any persons.")
+                log.Error("The investigation does not contain any persons.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -321,9 +321,9 @@ module InvestigationAPI =
                     [person]
                     |> Prompt.serializeXSLXWriterOutput (Contacts.toRows None)
                     |> log.Debug
-                | None -> log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation.")
+                | None -> log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the investigation.")
             | None -> 
-                log.Error("ERROR: The investigation does not contain any persons.")
+                log.Error("The investigation does not contain any persons.")
                
 
         /// Lists the full names of all persons included in the investigation.
@@ -350,7 +350,7 @@ module InvestigationAPI =
                         log.Debug($"--Person: {firstName} {midInitials} {lastName}")
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any persons.")
+                log.Error("The investigation does not contain any persons.")
 
     /// Functions for altering investigation publications.
     module Publications =
@@ -389,23 +389,23 @@ module InvestigationAPI =
                 else
                     let msg = $"Publication with the DOI {doi} does not exist in the investigation."
                     if containsFlag "AddIfMissing" publicationArgs then
-                        log.Warn($"WARNING: {msg}")
+                        log.Warn($"{msg}")
                         log.Info("Registering publication as AddIfMissing Flag was set.")
                         API.Publication.add publications publication
                         |> API.Investigation.setPublications investigation
                     else 
-                        log.Error($"ERROR: {msg}")
+                        log.Error($"{msg}")
                         log.Trace("AddIfMissing argument can be used to register publication with the update command if it is missing.")
                         investigation
             | None -> 
                 let msg = "The investigation does not contain any publications."
                 if containsFlag "AddIfMissing" publicationArgs then
-                    log.Warn($"WARNING: {msg}")
+                    log.Warn($"{msg}")
                     log.Info("Registering publication as AddIfMissing Flag was set.")
                     [publication]
                     |> API.Investigation.setPublications investigation
                 else 
-                    log.Error($"ERROR: {msg}")
+                    log.Error($"{msg}")
                     log.Trace("AddIfMissing argument can be used to register publication with the update command if it is missing.")
                     investigation
             |> Investigation.toFile investigationFilePath
@@ -436,10 +436,10 @@ module InvestigationAPI =
                     |> fun p -> API.Publication.updateBy ((=) publication) API.Update.UpdateAll p publications
                     |> API.Investigation.setPublications investigation
                 | None ->
-                    log.Error($"ERROR: Publication with the DOI {doi} does not exist in the investigation.")
+                    log.Error($"Publication with the DOI {doi} does not exist in the investigation.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any publications.")
+                log.Error("The investigation does not contain any publications.")
                 investigation  
             |> Investigation.toFile investigationFilePath
 
@@ -471,7 +471,7 @@ module InvestigationAPI =
             match investigation.Publications with
             | Some publications ->
                 if API.Publication.existsByDoi doi publications then
-                    log.Error($"ERROR: Publication with the DOI {doi} already exists in the investigation.")
+                    log.Error($"Publication with the DOI {doi} already exists in the investigation.")
                     publications
                 else
                     API.Publication.add publications publication
@@ -498,10 +498,10 @@ module InvestigationAPI =
                     API.Publication.removeByDoi doi publications
                     |> API.Investigation.setPublications investigation
                 else
-                    log.Error($"ERROR: Publication with the DOI {doi} does not exist in the investigation.")
+                    log.Error($"Publication with the DOI {doi} does not exist in the investigation.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any publications.")
+                log.Error("The investigation does not contain any publications.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -525,8 +525,8 @@ module InvestigationAPI =
                     [publication]
                     |> Prompt.serializeXSLXWriterOutput (Publications.toRows None)
                     |> log.Debug
-                | None -> log.Error($"ERROR: Publication with the DOI {doi} does not exist in the investigation.")
-            | None -> log.Error("ERROR: The investigation does not contain any publications.")
+                | None -> log.Error($"Publication with the DOI {doi} does not exist in the investigation.")
+            | None -> log.Error("The investigation does not contain any publications.")
 
         /// Lists the full names of all persons included in the investigation.
         let list (arcConfiguration : ArcConfiguration) = 
@@ -546,4 +546,4 @@ module InvestigationAPI =
                     log.Debug(sprintf "Publication (DOI): %s" (Option.defaultValue "" publication.DOI))
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any publications.")
+                log.Error("The investigation does not contain any publications.")

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -31,7 +31,7 @@ module StudyAPI =
         let identifier = getFieldValueByName "Identifier" studyArgs
 
         if StudyFile.exists arcConfiguration identifier then
-            log.Error("ERROR: Study file already exists.")
+            log.Error("Study file already exists.")
         else 
             StudyFile.create arcConfiguration identifier
 
@@ -43,7 +43,7 @@ module StudyAPI =
         log.Info("Start Study Update")
 
         // ?TODO? <- Test this : Add updateoption which updates by existing values and appends list
-        let updateOption = if containsFlag "ReplaceWithEmptyValues" studyArgs then API.Update.UpdateAllAppendLists else API.Update.UpdateByExisting            
+        let updateOption = if containsFlag "ReplaceWithEmptyValues" studyArgs then API.Update.UpdateAllAppendLists else API.Update.UpdateByExisting
 
         let identifier = getFieldValueByName "Identifier" studyArgs
 
@@ -71,23 +71,23 @@ module StudyAPI =
             else 
                 let msg = $"Study with the identifier {identifier} does not exist in the investigation."
                 if containsFlag "AddIfMissing" studyArgs then 
-                    log.Warn($"WARNING: {msg}")
+                    log.Warn($"{msg}")
                     log.Info("Registering study as AddIfMissing Flag was set.")
                     API.Study.add studies study
                     |> API.Investigation.setStudies investigation
                 else 
-                    log.Error($"ERROR: {msg}")
+                    log.Error($"{msg}")
                     log.Trace("AddIfMissing argument can be used to register study with the update command if it is missing.")
                     investigation
         | None -> 
             let msg = "The investigation does not contain any studies."
             if containsFlag "AddIfMissing" studyArgs then 
-                log.Warn($"WARNING: {msg}")
+                log.Warn($"{msg}")
                 log.Info("Registering study as AddIfMissing Flag was set.")
                 [study]
                 |> API.Investigation.setStudies investigation
             else 
-                log.Error($"ERROR: {msg}")
+                log.Error($"{msg}")
                 log.Trace("AddIfMissing argument can be used to register study with the update command if it is missing.")
                 investigation
         |> Investigation.toFile investigationFilePath
@@ -120,10 +120,10 @@ module StudyAPI =
                 API.Study.updateBy ((=) study) API.Update.UpdateAllAppendLists editedStudy studies
                 |> API.Investigation.setStudies investigation
             | None -> 
-                log.Error($"ERROR: Study with the identifier {identifier} does not exist in the investigation.")
+                log.Error($"Study with the identifier {identifier} does not exist in the investigation.")
                 investigation
         | None -> 
-            log.Error("ERROR: The investigation does not contain any studies.")
+            log.Error("The investigation does not contain any studies.")
             investigation
         |> Investigation.toFile investigationFilePath
 
@@ -156,7 +156,7 @@ module StudyAPI =
         | Some studies -> 
             match API.Study.tryGetByIdentifier identifier studies with
             | Some _ -> 
-                log.Error($"ERROR: Study with the identifier {identifier} already exists in the investigation file.")
+                log.Error($"Study with the identifier {identifier} already exists in the investigation file.")
                 studies
             | None -> 
                 API.Study.add studies study
@@ -182,7 +182,7 @@ module StudyAPI =
         let studyFilePath = IsaModelConfiguration.getStudiesFileName identifier arcConfiguration
 
         try System.IO.File.Delete studyFilePath with
-        | err -> log.Error($"ERROR: Couldn't delete study file:\n {err.ToString()}")
+        | err -> log.Error($"Couldn't delete study file:\n {err.ToString()}")
 
     /// Unregisters an existing study from the ARC's investigation file.
     let unregister (arcConfiguration : ArcConfiguration) (studyArgs : Map<string,Argument>) =
@@ -205,23 +205,23 @@ module StudyAPI =
                 match study.Assays with
                 | None | Some [] -> ()
                 | Some assays -> 
-                    log.Warn($"WARN: Study with the identifier {identifier} still contained following assays which might remain unregistered when the study is removed: ")
+                    log.Warn($"Study with the identifier {identifier} still contained following assays which might remain unregistered when the study is removed: ")
                     assays 
                     |> List.iter (fun a -> 
                         let identifier = 
                             a.FileName 
                              |> Option.bind (fun fn -> IsaModelConfiguration.tryGetAssayIdentifierOfFileName fn arcConfiguration)
                              |> Option.get
-                        log.Warn($"WARN: Assay \"{identifier}\"")
+                        log.Warn($"Assay \"{identifier}\"")
                     )
                     log.Info($"You can register the assays to a different study using \"arc a register\"")
                 API.Study.removeByIdentifier identifier studies 
                 |> API.Investigation.setStudies investigation
             | None -> 
-                log.Error($"ERROR: Study with the identifier {identifier} does not exist in the investigation file.")
+                log.Error($"Study with the identifier {identifier} does not exist in the investigation file.")
                 investigation
         | None -> 
-            log.Error("ERROR: The investigation does not contain any studies.")
+            log.Error("The investigation does not contain any studies.")
             investigation
         |> Investigation.toFile investigationFilePath
 
@@ -251,10 +251,10 @@ module StudyAPI =
                 |> Prompt.serializeXSLXWriterOutput Study.StudyInfo.toRows
                 |> log.Debug
             | None -> 
-                log.Error($"ERROR: Study with the identifier {identifier} does not exist in the investigation file.")
+                log.Error($"Study with the identifier {identifier} does not exist in the investigation file.")
                 ()
         | None -> 
-            log.Error("ERROR: The investigation does not contain any studies.")
+            log.Error("The investigation does not contain any studies.")
             
 
     /// Lists all study identifiers registered in this ARC's investigation file.
@@ -277,7 +277,7 @@ module StudyAPI =
             |> List.choose (fun s -> 
                 match s.Identifier with
                 | None | Some "" -> 
-                    log.Warn("WARN: Study does not have identifier")
+                    log.Warn("Study does not have identifier")
                     None
                 | Some i -> Some i
             ) 
@@ -288,19 +288,19 @@ module StudyAPI =
         let combined = Set.union studyIdentifiers studyFileIdentifiers
 
         if not onlyRegistered.IsEmpty then
-            log.Warn("WARN: Arc contains following registered studies that have no associated file:")
+            log.Warn("The ARC contains following registered studies that have no associated file:")
             onlyRegistered
             |> Seq.iter ((sprintf "WARN: %s") >> log.Warn) 
             log.Info($"You can init the study file using \"arc s init\"")
 
         if not onlyInitialized.IsEmpty then
-            log.Warn("WARN: Arc contains study files with the following identifiers not registered in the investigation:")
+            log.Warn("The ARC contains study files with the following identifiers not registered in the investigation:")
             onlyInitialized
             |> Seq.iter ((sprintf "WARN: %s") >> log.Warn) 
             log.Info($"You can register the study using \"arc s register\"")
 
         if combined.IsEmpty then
-            log.Error("ERROR: ARC does not contain any studies.")
+            log.Error("The ARC does not contain any studies.")
 
         combined
         |> Seq.iter (fun identifier ->
@@ -362,32 +362,32 @@ module StudyAPI =
                         else
                             let msg = $"Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}."
                             if containsFlag "AddIfMissing" personArgs then
-                                log.Warn($"WARN: {msg}")
+                                log.Warn($"{msg}")
                                 log.Info("Registering person as AddIfMissing Flag was set.")
                                 API.Person.add persons person
                                 |> API.Study.setContacts study
                             else 
-                                log.Error($"ERROR: {msg}")
+                                log.Error($"{msg}")
                                 log.Trace("AddIfMissing argument can be used to register person with the update command if it is missing.")
                                 study
                     | None -> 
                         let msg = $"The study with the identifier {studyIdentifier} does not contain any persons."
                         if containsFlag "AddIfMissing" personArgs then
-                            log.Warn($"WARNING: {msg}")
+                            log.Warn($"{msg}")
                             log.Info("Registering person as AddIfMissing Flag was set.")
                             [person]
                             |> API.Study.setContacts study
                         else 
-                            log.Error($"ERROR: {msg}")
+                            log.Error($"{msg}")
                             log.Trace("AddIfMissing argument can be used to register person with the update command if it is missing.")
                             study
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
         
@@ -427,16 +427,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         | None ->
-                            log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any persons.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any persons.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -494,10 +494,10 @@ module StudyAPI =
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
     
@@ -531,16 +531,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         else
-                            log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any persons.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any persons.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -572,13 +572,13 @@ module StudyAPI =
                             [person]
                             |> Prompt.serializeXSLXWriterOutput (Contacts.toRows None)
                             |> log.Debug
-                        | None -> log.Error($"ERROR: Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}.")
+                        | None -> log.Error($"Person with the name {firstName} {midInitials} {lastName} does not exist in the study with the identifier {studyIdentifier}.")
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any persons.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any persons.")
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
 
         /// Lists the full names of all persons included in the investigation.
@@ -612,7 +612,7 @@ module StudyAPI =
                     | None -> ()
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
     /// Functions for altering investigation Publications.
     module Publications =
@@ -657,32 +657,32 @@ module StudyAPI =
                         else
                             let msg = $"Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}."
                             if containsFlag "AddIfMissing" publicationArgs then
-                                log.Warn($"WARNING: {msg}")
+                                log.Warn($"{msg}")
                                 log.Info("Registering publication as AddIfMissing Flag was set.")
                                 API.Publication.add publications publication
                                 |> API.Study.setPublications study
                             else 
-                                log.Error($"ERROR: {msg}")
+                                log.Error($"{msg}")
                                 log.Trace("AddIfMissing argument can be used to register publication with the update command if it is missing.")
                                 study
                     | None -> 
                         let msg = $"The study with the identifier {studyIdentifier} does not contain any publications."
                         if containsFlag "AddIfMissing" publicationArgs then
-                            log.Warn($"WARNING: {msg}")
+                            log.Warn($"{msg}")
                             log.Info("Registering publication as AddIfMissing Flag was set.")
                             [publication]
                             |> API.Study.setPublications study
                         else 
-                            log.Error($"ERROR: {msg}")
+                            log.Error($"{msg}")
                             log.Trace("AddIfMissing argument can be used to register publication with the update command if it is missing.")
                             study
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
         
@@ -721,16 +721,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         | None ->
-                            log.Error($"ERROR: Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any publications.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any publications.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -768,7 +768,7 @@ module StudyAPI =
                     match study.Publications with
                     | Some publications -> 
                         if API.Publication.existsByDoi doi publications then
-                            log.Error($"ERROR: Publication with the DOI {doi} already exists in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Publication with the DOI {doi} already exists in the study with the identifier {studyIdentifier}.")
                             publications
                         else
                             API.Publication.add publications publication
@@ -778,10 +778,10 @@ module StudyAPI =
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -812,16 +812,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         else
-                            log.Error($"ERROR: Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any publications.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any publications.")
                         investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -852,13 +852,13 @@ module StudyAPI =
                             |> Prompt.serializeXSLXWriterOutput (Publications.toRows None)
                             |> log.Debug
                         | None -> 
-                            log.Error($"ERROR: Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Publication with the DOI {doi} does not exist in the study with the identifier {studyIdentifier}.")
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any publications.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any publications.")
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
 
         /// Lists the DOIs of all publications included in the investigation study.
@@ -884,7 +884,7 @@ module StudyAPI =
                     | None -> ()
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
 
     /// Functions for altering investigation Designs.
@@ -927,32 +927,32 @@ module StudyAPI =
                         else
                             let msg = $"Design with the name {name} does not exist in the study with the identifier {studyIdentifier}."
                             if containsFlag "AddIfMissing" designArgs then
-                                log.Warn($"WARNING: {msg}")
+                                log.Warn($"{msg}")
                                 log.Info("Registering design as AddIfMissing Flag was set.")
                                 API.OntologyAnnotation.add designs design
                                 |> API.Study.setDescriptors study
                             else 
-                                log.Error($"ERROR: {msg}")
+                                log.Error($"{msg}")
                                 log.Trace("AddIfMissing argument can be used to register design with the update command if it is missing.")
                                 study
                     | None -> 
                         let msg = $"The study with the identifier {studyIdentifier} does not contain any design descriptors."
                         if containsFlag "AddIfMissing" designArgs then
-                            log.Warn($"WARNING: {msg}")
+                            log.Warn($"{msg}")
                             log.Info("Registering design as AddIfMissing Flag was set.")
                             [design]
                             |> API.Study.setDescriptors study
                         else 
-                            log.Error($"ERROR: {msg}")
+                            log.Error($"{msg}")
                             log.Trace("AddIfMissing argument can be used to register design with the update command if it is missing.")
                             study
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
         
@@ -990,16 +990,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         | None ->
-                            log.Error($"ERROR: Design with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Design with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any design descriptors.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any design descriptors.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1033,7 +1033,7 @@ module StudyAPI =
                     match study.StudyDesignDescriptors with
                     | Some designs -> 
                         if API.OntologyAnnotation.existsByName (AnnotationValue.fromString name) designs then
-                            log.Error($"ERROR: Design with the name {name} already exists in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Design with the name {name} already exists in the study with the identifier {studyIdentifier}.")
                             designs
                         else
                             API.OntologyAnnotation.add designs design
@@ -1043,10 +1043,10 @@ module StudyAPI =
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1077,16 +1077,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         else
-                            log.Error($"ERROR: Design with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Design with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any design descriptors.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any design descriptors.")
                         investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1117,13 +1117,13 @@ module StudyAPI =
                             |> Prompt.serializeXSLXWriterOutput (DesignDescriptors.toRows None)
                             |> log.Debug
                         | None -> 
-                            log.Error($"ERROR: Design with the DOI {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Design with the DOI {name} does not exist in the study with the identifier {studyIdentifier}.")
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any design descriptors.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any design descriptors.")
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
         
         /// Lists the designs included in the investigation study.
         let list (arcConfiguration : ArcConfiguration) = 
@@ -1148,7 +1148,7 @@ module StudyAPI =
                     | None -> ()
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
     /// Functions for altering investigation factors.
     module Factors =
@@ -1190,32 +1190,32 @@ module StudyAPI =
                         else
                             let msg = $"Factor with the name {name} does not exist in the study with the identifier {studyIdentifier}."
                             if containsFlag "AddIfMissing" factorArgs then
-                                log.Warn($"WARNING: {msg}")
+                                log.Warn($"{msg}")
                                 log.Info("Registering factor as AddIfMissing Flag was set.")
                                 API.Factor.add factors factor
                                 |> API.Study.setFactors study
                             else 
-                                log.Error($"ERROR: {msg}")
+                                log.Error($"{msg}")
                                 log.Trace("AddIfMissing argument can be used to register factor with the update command if it is missing.")
                                 study
                     | None -> 
                         let msg = $"The study with the identifier {studyIdentifier} does not contain any factors."
                         if containsFlag "AddIfMissing" factorArgs then
-                            log.Warn($"WARNING: {msg}")
+                            log.Warn($"{msg}")
                             log.Info("Registering factor as AddIfMissing Flag was set.")
                             [factor]
                             |> API.Study.setFactors study
                         else 
-                            log.Error($"ERROR: {msg}")
+                            log.Error($"{msg}")
                             log.Trace("AddIfMissing argument can be used to register factor with the update command if it is missing.")
                             study
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
         
@@ -1253,16 +1253,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         | None ->
-                            log.Error($"ERROR: Factor with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Factor with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any factors.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any factors.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1297,7 +1297,7 @@ module StudyAPI =
                     match study.Factors with
                     | Some factors -> 
                         if API.Factor.existsByName name factors then
-                            log.Error($"ERROR: Factor with the name {name} already exists in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Factor with the name {name} already exists in the study with the identifier {studyIdentifier}.")
                             factors
                         else
                             API.Factor.add factors factor
@@ -1306,10 +1306,10 @@ module StudyAPI =
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1340,16 +1340,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         else
-                            log.Error($"ERROR: Factor with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Factor with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any factors.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any factors.")
                         investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1380,13 +1380,13 @@ module StudyAPI =
                             |> Prompt.serializeXSLXWriterOutput (Factors.toRows None)
                             |> log.Debug
                         | None -> 
-                            log.Error($"ERROR: Factor with the DOI {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Factor with the DOI {name} does not exist in the study with the identifier {studyIdentifier}.")
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any factors.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any factors.")
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
         /// Lists the factors included in the investigation study.
         let list (arcConfiguration : ArcConfiguration) = 
@@ -1411,7 +1411,7 @@ module StudyAPI =
                     | None -> ()
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
 
     /// Functions for altering investigation protocols.
     module Protocols =
@@ -1463,32 +1463,32 @@ module StudyAPI =
                         else
                             let msg = $"Protocol with the name {name} does not exist in the study with the identifier {studyIdentifier}."
                             if containsFlag "AddIfMissing" protocolArgs then
-                                log.Warn($"WARNING: {msg}")
+                                log.Warn($"{msg}")
                                 log.Info("Registering protocol as AddIfMissing Flag was set.")
                                 API.Protocol.add protocols protocol
                                 |> API.Study.setProtocols study
                             else 
-                                log.Error($"ERROR: {msg}")
+                                log.Error($"{msg}")
                                 log.Trace("AddIfMissing argument can be used to register protocol with the update command if it is missing.")
                                 study
                     | None -> 
                         let msg = $"The study with the identifier {studyIdentifier} does not contain any protocols."
                         if containsFlag "AddIfMissing" protocolArgs then
-                            log.Warn($"WARNING: {msg}")
+                            log.Warn($"{msg}")
                             log.Info("Registering protocol as AddIfMissing Flag was set.")
                             [protocol]
                             |> API.Study.setProtocols study
                         else 
-                            log.Error($"ERROR: {msg}")
+                            log.Error($"{msg}")
                             log.Trace("AddIfMissing argument can be used to register protocol with the update command if it is missin.g")
                             study
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
         
@@ -1526,16 +1526,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         | None ->
-                            log.Error($"ERROR: Protocol with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Protocol with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any protocols.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any protocols.")
                         investigation
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1580,7 +1580,7 @@ module StudyAPI =
                     match study.Protocols with
                     | Some protocols -> 
                         if API.Protocol.existsByName name protocols then
-                            log.Error($"ERROR: Protocol with the name {name} already exists in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Protocol with the name {name} already exists in the study with the identifier {studyIdentifier}.")
                             protocols
                         else
                             API.Protocol.add protocols protocol
@@ -1589,10 +1589,10 @@ module StudyAPI =
                     |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                     |> API.Investigation.setStudies investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error($"ERROR: The investigation does not contain any studies.")
+                log.Error($"The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1623,16 +1623,16 @@ module StudyAPI =
                             |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                             |> API.Investigation.setStudies investigation
                         else
-                            log.Error($"ERROR: Protocol with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Protocol with the name {name} does not exist in the study with the identifier {studyIdentifier}.")
                             investigation
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any protocols.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any protocols.")
                         investigation
                 | None ->
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1655,7 +1655,7 @@ module StudyAPI =
                     Json.Protocol.fromFile path |> Some
                 |> Option.map (fun p -> 
                     if p.Name.IsNone then
-                        log.Error("ERROR: Given protocol does not contain a name, please add it in the editor.")
+                        log.Error("Given protocol does not contain a name, please add it in the editor.")
                         ArgumentProcessing.Prompt.createIsaItemQuery editor
                             (List.singleton >> Protocols.toRows None) 
                             (Protocols.fromRows None 1 >> fun (_,_,_,items) -> items.Head) 
@@ -1681,11 +1681,11 @@ module StudyAPI =
                             if API.Protocol.existsByName name protocols then
                                 let msg = $"Protocol with the name {name} already exists in the study with the identifier {studyIdentifier}."
                                 if containsFlag "UpdateExisting" protocolArgs then
-                                    log.Warn($"WARNING: {msg}")
+                                    log.Warn($"{msg}")
                                     log.Info("Updating protocol as \"UpdateExisting\" flag was given.")
                                     API.Protocol.updateByName API.Update.UpdateAll protocol protocols
                                 else
-                                    log.Error($"ERROR: {msg}")
+                                    log.Error($"{msg}")
                                     log.Info("Not updating protocol as \"UpdateExisting\" flag was not given.")
                                     protocols
                             else
@@ -1696,13 +1696,13 @@ module StudyAPI =
                         |> fun s -> API.Study.updateByIdentifier API.Update.UpdateAll s studies
                         |> API.Investigation.setStudies investigation
                     | None ->
-                        log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                        log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
                         investigation
                 | None ->
-                    log.Error("ERROR: The process file did not contain a protocol.")
+                    log.Error("The process file did not contain a protocol.")
                     investigation
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 investigation
             |> Investigation.toFile investigationFilePath
 
@@ -1733,13 +1733,13 @@ module StudyAPI =
                             |> Prompt.serializeXSLXWriterOutput (Protocols.toRows None)
                             |> log.Debug
                         | None -> 
-                            log.Error($"ERROR: Protocol with the DOI {name} does not exist in the study with the identifier {studyIdentifier}.")
+                            log.Error($"Protocol with the DOI {name} does not exist in the study with the identifier {studyIdentifier}.")
                     | None -> 
-                        log.Error($"ERROR: The study with the identifier {studyIdentifier} does not contain any protocols.")
+                        log.Error($"The study with the identifier {studyIdentifier} does not contain any protocols.")
                 | None -> 
-                    log.Error($"ERROR: Study with the identifier {studyIdentifier} does not exist in the investigation file.")
+                    log.Error($"Study with the identifier {studyIdentifier} does not exist in the investigation file.")
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")
                 
 
         /// Lists the protocols included in the investigation study.
@@ -1765,4 +1765,4 @@ module StudyAPI =
                     | None -> ()
                 )
             | None -> 
-                log.Error("ERROR: The investigation does not contain any studies.")
+                log.Error("The investigation does not contain any studies.")

--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -40,7 +40,7 @@ module ArgumentProcessing =
         let log = Logging.createLogger "ArgumentProcessingContainsFlagLog"
         match Map.tryFind k arguments with
         | Some (Field _ )   -> 
-            log.Fatal($"ERROR: Argument {k} is not a flag, but a field.")
+            log.Fatal($"Argument {k} is not a flag, but a field.")
             raise (Exception(""))
         | Some (Flag)       -> true
         | None              -> false
@@ -59,7 +59,7 @@ module ArgumentProcessing =
         match Map.find k arguments with
         | Field v -> v
         | Flag -> 
-            log.Fatal($"ERROR: Argument {k} is not a field, but a flag.")
+            log.Fatal($"Argument {k} is not a field, but a flag.")
             raise (Exception(""))
 
     /// For a given discriminated union value, returns the field name and the value.
@@ -113,7 +113,7 @@ module ArgumentProcessing =
                     | None -> None, false
                 unionCase.Name, createAnnotatedArgument value toolTip isMandatory isFlag
             | _ ->
-                log.Fatal($"ERROR: Cannot parse argument {unionCase.Name} because its parsing rules were not yet implemented.")
+                log.Fatal($"Cannot parse argument {unionCase.Name} because its parsing rules were not yet implemented.")
                 raise (Exception(""))
         )
 
@@ -238,7 +238,7 @@ module ArgumentProcessing =
             with
             | err -> 
                 delete filePath
-                log.Fatal($"ERROR: Could not parse query:\n {err.ToString()}")
+                log.Fatal($"Could not parse query:\n {err.ToString()}")
                 raise (Exception(""))
 
         /// Opens a textprompt containing the result of the serialized input parameters. Returns the deserialized user input.
@@ -306,7 +306,7 @@ module ArgumentProcessing =
                                 match splitAtFirst ':' x with
                                 | k, Field v ->
                                     ISADotNet.XLSX.SparseRow.fromValues [k;v]
-                                | _ -> log.Fatal("ERROR: File was corrupted in Editor."); raise (Exception(""))
+                                | _ -> log.Fatal("File was corrupted in Editor."); raise (Exception(""))
                             )
                 )
                 |> fun rs -> readF (rs.GetEnumerator()) 
@@ -324,7 +324,7 @@ module ArgumentProcessing =
                 |> Array.map (fun x ->
                     match splitAtFirst '=' x with
                     | k, Field v -> k,v
-                    | _ -> log.Fatal("ERROR: File was corrupted in Editor."); raise (Exception(""))
+                    | _ -> log.Fatal("File was corrupted in Editor."); raise (Exception(""))
                 )
                 |> IniData.fromNameValuePairs
             createQuery editorPath serializeF deserializeF iniData

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -315,7 +315,10 @@ module IniData =
         arcCommanderDataFolder
 
     /// Returns the full path of the data folder for an ARC. If the ArcCommander is used in a non-ARC directory returns None.
-    let tryGetArcDataFolderPath arcName arcCommanderDataFolder =
-        if Directory.Exists(arcCommanderDataFolder) then
-            Some (Path.Combine(arcCommanderDataFolder, arcName))
+    let tryGetArcDataFolderPath arcDir arcCommanderDataFolder =
+        // TO DO: rework when a function to check an ARC's integrity or to verify that a folder is an ARC is available
+        // temporary solution: current folder is an ARC if a .arc folder exists
+        let arcName = DirectoryInfo(arcDir).Name
+        let isArc = Directory.Exists(Path.Combine(arcDir, ".arc"))
+        if isArc then Some (Path.Combine(arcCommanderDataFolder, arcName))
         else None

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -306,3 +306,16 @@ module IniData =
         | Some ini -> ini
         | None -> addValue name value iniData
         |> toFile path
+
+    /// Creates a folder for the ArcCommander's data files in `$XDG_CONFIG_DIRS`.
+    let createDataFolder () =
+        let appDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify)
+        let arcCommanderDataFolder = Path.Combine(appDataFolder, "DataPLANT", "ArcCommander")
+        Directory.CreateDirectory(arcCommanderDataFolder) |> ignore
+        arcCommanderDataFolder
+
+    /// Returns the full path of the data folder for an ARC. If the ArcCommander is used in a non-ARC directory returns None.
+    let tryGetArcDataFolderPath arcName arcCommanderDataFolder =
+        if Directory.Exists(arcCommanderDataFolder) then
+            Some (Path.Combine(arcCommanderDataFolder, arcName))
+        else None

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -21,7 +21,7 @@ module IniData =
         if m.Success then
             m.Groups.[1].Value,m.Groups.[2].Value
         else 
-            log.Fatal(sprintf "ERROR: Name \"%s\" could not be split into section and key, it must be of form \"section.key\"." name)
+            log.Fatal(sprintf "Name \"%s\" could not be split into section and key, it must be of form \"section.key\"." name)
             raise (Exception(""))
 
     let splitValues (value : string) = value.Split(';')
@@ -36,7 +36,7 @@ module IniData =
             RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.OSX)             -> Unix
         | _                                                             -> 
-            log.Fatal($"ERROR: OS not supported. Only Windows, MacOS and Linux are supported.")
+            log.Fatal($"OS not supported. Only Windows, MacOS and Linux are supported.")
             raise (Exception(""))
 
     /// Creates a default config file in the user's config folder (AppData\Local in Windows, ~/config in Unix).
@@ -99,7 +99,7 @@ module IniData =
             | _                         -> createDefault (); inConfigFolder // if nothing found, config gets created
             |> Some
         with e -> 
-            log.Error($"ERROR: tryGetGlobalConfigPath failed with:\n {e.ToString()}")
+            log.Error($"tryGetGlobalConfigPath failed with:\n {e.ToString()}")
             None
         //| _ -> failwith "ERROR: No global config file found. Initiation of default config file not possible.\nPlease add the specific config file for your OS to your config folder."
         //Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory,"config")
@@ -189,7 +189,7 @@ module IniData =
             |> Option.bind (tryGetValue key)
         with 
         | err -> 
-            log.Error($"ERROR: Could not retrieve value with given name.\n {err.ToString()}")
+            log.Error($"Could not retrieve value with given name.\n {err.ToString()}")
             None
 
     /// Returns true if the name (section+key) is set in the iniData.
@@ -211,7 +211,7 @@ module IniData =
             iniData.[section].[key] <- value
             Some iniData
         else
-            log.Error($"ERROR: Name {name} does not exist in the config.")
+            log.Error($"Name {name} does not exist in the config.")
             None
 
     /// If the name is already set in the config, assigns a new value to it.
@@ -232,7 +232,7 @@ module IniData =
             iniData.[section].RemoveKey key |> ignore
             Some iniData
         else
-            log.Error($"ERROR: Name {name} does not exist in the config.")
+            log.Error($"Name {name} does not exist in the config.")
             None
 
     /// If the name is set in the config, removes it.
@@ -249,7 +249,7 @@ module IniData =
     let tryAddValue (name : string) (value : string) (iniData : IniData) =
         let log = Logging.createLogger "IniDataTryAddValueLog"
         if nameExists (name : string) (iniData : IniData) then
-            log.Error($"ERROR: Name {name} already exists in the config.")
+            log.Error($"Name {name} already exists in the config.")
             Some iniData
         else
             let section,key = splitName name 

--- a/src/ArcCommander/Logging.fs
+++ b/src/ArcCommander/Logging.fs
@@ -15,10 +15,20 @@ module Logging =
         let config = new LoggingConfiguration()
 
         // initialise base console target, can be modified
-        let consoleTarget = new ColoredConsoleTarget("console")
+        let consoleTarget1 = new ColoredConsoleTarget("console")
         // new parameters for console target
-        let layoutConsole = new Layouts.SimpleLayout (@"${message} ${exception}")
-        consoleTarget.Layout <- layoutConsole
+        let layoutConsole1 = new Layouts.SimpleLayout (@"${message} ${exception}")
+        consoleTarget1.Layout <- layoutConsole1
+
+        // second console target for alert messages (error & fatal)
+        let consoleTarget2 = new ColoredConsoleTarget("console")
+        let layoutConsole2 = new Layouts.SimpleLayout (@"${level:uppercase=true}: {message} ${exception}")
+        consoleTarget2.Layout <- layoutConsole2
+
+        // third console target for alert messages (warn)
+        let consoleTarget3 = new ColoredConsoleTarget("console")
+        let layoutConsole3 = new Layouts.SimpleLayout (@"$WARNING: {message} ${exception}")
+        consoleTarget3.Layout <- layoutConsole3
 
         // initialise base file target, can be modified
         let fileTarget = new FileTarget("file")
@@ -28,7 +38,7 @@ module Logging =
         fileTarget.FileName <- fileName
         fileTarget.Layout <- layoutFile
 
-        config.AddTarget(consoleTarget)
+        config.AddTarget(consoleTarget1)
         config.AddTarget(fileTarget)
 
         // define rules for colors that shall differ from the default color theme
@@ -44,22 +54,22 @@ module Logging =
         fatalColorRule.BackgroundColor <- ConsoleOutputColor.DarkYellow
 
         // add the newly defined rules to the console target
-        consoleTarget.RowHighlightingRules.Add(warnColorRule)
-        consoleTarget.RowHighlightingRules.Add(errorColorRule)
-        consoleTarget.RowHighlightingRules.Add(fatalColorRule)
+        consoleTarget2.RowHighlightingRules.Add(errorColorRule)
+        consoleTarget2.RowHighlightingRules.Add(fatalColorRule)
+        consoleTarget3.RowHighlightingRules.Add(warnColorRule)
 
         // declare which results in a log in which target
-        if verbosity >= 1 then config.AddRuleForOneLevel(LogLevel.Info, consoleTarget) // info results shall be used for verbosity 1
+        if verbosity >= 1 then config.AddRuleForOneLevel(LogLevel.Info, consoleTarget1) // info results shall be used for verbosity 1
         config.AddRuleForOneLevel(LogLevel.Info, fileTarget) // info results shall be written to log file, regardless of verbosity
-        if verbosity = 2 then config.AddRuleForOneLevel(LogLevel.Trace, consoleTarget) // trace results shall be used for verbosity 2
+        if verbosity = 2 then config.AddRuleForOneLevel(LogLevel.Trace, consoleTarget1) // trace results shall be used for verbosity 2
         config.AddRuleForOneLevel(LogLevel.Trace, fileTarget) // trace results shall be written to log file, regardless of verbosity
-        config.AddRuleForOneLevel(LogLevel.Debug, consoleTarget) // shall be used for results that shall always be printed, regardless of verbosity
+        config.AddRuleForOneLevel(LogLevel.Debug, consoleTarget1) // shall be used for results that shall always be printed, regardless of verbosity
         config.AddRuleForOneLevel(LogLevel.Debug, fileTarget)
-        if verbosity >= 1 then config.AddRuleForOneLevel(LogLevel.Warn, consoleTarget) // warnings shall be used for non-critical events if verbosity is above 0
+        if verbosity >= 1 then config.AddRuleForOneLevel(LogLevel.Warn, consoleTarget3) // warnings shall be used for non-critical events if verbosity is above 0
         config.AddRuleForOneLevel(LogLevel.Warn, fileTarget)
-        config.AddRuleForOneLevel(LogLevel.Error, consoleTarget) // errors shall be used for critical events that lead to an abort of the desired task but still led the ArcCommander terminate successfully
+        config.AddRuleForOneLevel(LogLevel.Error, consoleTarget2) // errors shall be used for critical events that lead to an abort of the desired task but still led the ArcCommander terminate successfully
         config.AddRuleForOneLevel(LogLevel.Error, fileTarget)
-        config.AddRuleForOneLevel(LogLevel.Fatal, consoleTarget) // fatal errors shall be used for critical events that cause ArcCommander exceptions leading to an unsuccessful termination
+        config.AddRuleForOneLevel(LogLevel.Fatal, consoleTarget2) // fatal errors shall be used for critical events that cause ArcCommander exceptions leading to an unsuccessful termination
         config.AddRuleForOneLevel(LogLevel.Fatal, fileTarget) // impairing the ARC structure
    
         // activate config for logger

--- a/src/ArcCommander/Logging.fs
+++ b/src/ArcCommander/Logging.fs
@@ -6,6 +6,12 @@ open NLog.Config
 open NLog.Targets
 open NLog.Conditions
 
+// for testing purposes: commands to trigger different log levels: 
+// - INFO & TRACE: `arc -v 2 init`
+// - DEBUG: `arc -v 0 --version`
+// - WARN: `arc a update --addifmissing` when an ARC was already initialized, an investigation was already created, a study with an id was already added, and an assay with another id than the study was already added. In the editor prompt, fill in the assay's id in the `AssayIdentifier` field and the first study's id in the `StudyIdentifier` field, save and close the prompt
+// - ERROR: `arc asd`. Argu Usage prompt should not be logged (check log file)
+// - FATAL: `arc a add`. Close the editor prompt without saving
 /// Functions for working with the NLog logger.
 module Logging =
 
@@ -22,19 +28,19 @@ module Logging =
 
         // second console target for alert messages (error & fatal)
         let consoleTarget2 = new ColoredConsoleTarget("console")
-        let layoutConsole2 = new Layouts.SimpleLayout (@"${level:uppercase=true}: {message} ${exception}")
+        let layoutConsole2 = new Layouts.SimpleLayout (@"${level:uppercase=true}: ${message} ${exception}")
         consoleTarget2.Layout <- layoutConsole2
 
         // third console target for alert messages (warn)
         let consoleTarget3 = new ColoredConsoleTarget("console")
-        let layoutConsole3 = new Layouts.SimpleLayout (@"$WARNING: {message} ${exception}")
+        let layoutConsole3 = new Layouts.SimpleLayout (@"WARNING: ${message} ${exception}")
         consoleTarget3.Layout <- layoutConsole3
 
         // initialise base file target, can be modified
         let fileTarget = new FileTarget("file")
         // new parameters for file target
         let fileName = new Layouts.SimpleLayout (System.IO.Path.Combine (folderPath, @"ArcCommander.log"))
-        let layoutFile = new Layouts.SimpleLayout ("${longdate} ${logger} ${level:uppercase=true}: ${message} ${exception}")
+        let layoutFile = new Layouts.SimpleLayout ("${longdate} ${logger} ${level:uppercase=true}: ${message}")
         fileTarget.FileName <- fileName
         fileTarget.Layout <- layoutFile
 
@@ -85,9 +91,12 @@ module Logging =
 
     /// Takes a logger and an exception and separates usage and error messages. Usage messages will be printed into the console while error messages will be logged.
     let handleExceptionMessage (log : NLog.Logger) (exn : Exception) =
-        // separate usage message (Argu) and error messages. Error messages shall be logged, usage messages shall not
-        match exn.Message.Contains("USAGE") || exn.Message.Contains("SUBCOMMANDS"), exn.Message.Contains("ERROR") with
-        | true,true -> // exception message contains usage AND error messages
+        // separate usage message (Argu) and error messages. Error messages shall be logged, usage messages shall not, empty error message shall not appear at all
+        let isUsageMessage = exn.Message.Contains("USAGE") || exn.Message.Contains("SUBCOMMANDS")
+        let isErrorMessage = exn.Message.Contains("ERROR")
+        let isEmptyMessage = exn.Message = ""
+        match isUsageMessage, isErrorMessage, isEmptyMessage with
+        | true,true,false -> // exception message contains usage AND error messages
             let eMsg, uMsg = 
                 exn.Message.Split(Environment.NewLine) // '\n' leads to parsing problems
                 |> fun arr ->
@@ -95,8 +104,9 @@ module Logging =
                     arr |> Array.filter (fun t -> t.Contains("ERROR") |> not) |> String.concat "\n" // Argu usage instruction shall not be logged as error
             log.Error(eMsg)
             printfn "%s" uMsg
-        | true,false -> printfn "%s" exn.Message // exception message contains usage message but NO error message
-        | _ -> log.Error(exn.Message) // everything else will be an error message
+        | true,false,false -> printfn "%s" exn.Message // exception message contains usage message but NO error message
+        | false,false,true -> () // empty error message
+        | _ -> log.Error(exn.Message) // everything else will be a non-empty error message
     
     /// Checks if a message (string) is empty and if it is not, applies a logging function to it.
     let checkNonLog s (logging : string -> unit) = if s <> "" then logging s

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -31,7 +31,7 @@ let processCommand (arcConfiguration : ArcConfiguration) commandF (r : ParseResu
             let stillMissingMandatoryArgs, arguments =
                 Prompt.createMissingArgumentQuery editor annotatedArguments
             if stillMissingMandatoryArgs then
-                log.Fatal("ERROR: Mandatory arguments were not given either via cli or editor prompt.")
+                log.Fatal("Mandatory arguments were not given either via cli or editor prompt.")
                 raise (Exception(""))
             arguments
         // Opens a command line prompt asking for addtional information if the "forceeditor" flag is set.

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -239,10 +239,16 @@ let main argv =
             |> ArcConfiguration.load
         // <-----
         
-        // here the logging config gets created
-        let arcFolder = Path.Combine(arcConfiguration.General.Item "workdir", arcConfiguration.General.Item "rootfolder")
-        Directory.CreateDirectory(arcFolder) |> ignore
-        Logging.generateConfig arcFolder (GeneralConfiguration.getVerbosity arcConfiguration)
+        let arcCommanderDataFolder = IniData.createDataFolder ()
+        // TO DO: rework when a function to check an ARC's integrity or to verify that a folder is an ARC is available
+        // temporary solution: current folder is an ARC if a .arc folder exists
+        let isArc = Directory.Exists(Path.Combine(workingDir, ".arc"))
+        let arcDataFolder =
+            let arcName = DirectoryInfo(workingDir).Name
+            let fullPath = Path.Combine(arcCommanderDataFolder, arcName)
+            if isArc then fullPath
+            else arcCommanderDataFolder
+        Logging.generateConfig arcDataFolder (GeneralConfiguration.getVerbosity arcConfiguration)
         let log = Logging.createLogger "ArcCommanderMainLog"
 
         // Try parse the command line arguments

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -6,6 +6,7 @@ open ArcCommander.ArgumentProcessing
 open ArcCommander.Commands
 open ArcCommander.APIs
 open ArcCommander.ExternalExecutables
+open ArcCommander.IniData
 
 open System
 open System.IO
@@ -240,13 +241,9 @@ let main argv =
         // <-----
         
         let arcCommanderDataFolder = IniData.createDataFolder ()
-        // TO DO: rework when a function to check an ARC's integrity or to verify that a folder is an ARC is available
-        // temporary solution: current folder is an ARC if a .arc folder exists
-        let isArc = Directory.Exists(Path.Combine(workingDir, ".arc"))
-        let arcDataFolder =
-            let arcName = DirectoryInfo(workingDir).Name
-            let fullPath = Path.Combine(arcCommanderDataFolder, arcName)
-            if isArc then fullPath
+        let arcDataFolder = 
+            if (tryGetArcDataFolderPath workingDir arcCommanderDataFolder).IsSome then 
+                (tryGetArcDataFolderPath workingDir arcCommanderDataFolder).Value
             else arcCommanderDataFolder
         Logging.generateConfig arcDataFolder (GeneralConfiguration.getVerbosity arcConfiguration)
         let log = Logging.createLogger "ArcCommanderMainLog"


### PR DESCRIPTION
- Closes #102 
- New logging rules:
  - It is not needed anymore to write "ERROR" or "WARNING" at the beginning of log messages of level `ERROR`, `FATAL`, or `WARN`, this is now done automatically for these levels