### PR TITLE
Add .gitignore and ReadMe files to empty folders

### DIFF
--- a/src/ArcCommander/.gitignore
+++ b/src/ArcCommander/.gitignore
@@ -1,0 +1,27 @@
+# exclude everything..
+*
+#.. except ..
+
+
+#Include ARC folders
+!.arc/
+!.arc/**
+!assays/
+!assays/**
+!externals/
+!externals/**
+!workflows/
+!workflows/**
+!runs/
+!runs/**
+
+
+#Include ARC top level files
+!.gitattributes
+!.gitignore
+!README.md
+
+
+#Include ISA top level files
+!isa.investigation.xlsx
+!*isa.study.xlsx

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -44,7 +44,10 @@ module ArcAPI =
         log.Trace("Initiate folder structure")
 
         ArcConfiguration.getRootFolderPaths arcConfiguration
-        |> Array.iter (Directory.CreateDirectory >> ignore)
+        |> Array.iter (
+            Directory.CreateDirectory 
+            >> fun dir -> File.Create(Path.Combine(dir.FullName, "README.md")) |> ignore 
+        )
 
         log.Trace("Set configuration")
 

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -66,15 +66,21 @@ module ArcAPI =
 
             Fake.Tools.Git.Repository.init workDir false true
 
+            let gitignoreAppPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".gitignore")
+            let gitignoreArcPath = Path.Combine(workDir, ".gitignore")
+            log.Trace($"Copy .gitignore from {gitignoreAppPath} to {gitignoreArcPath}")
+            File.Copy(gitignoreAppPath, gitignoreArcPath)
+
+            log.Trace("Add remote repository")
             match repositoryAdress with
             | None -> ()
             | Some remote ->
                 GitHelper.executeGitCommand workDir ("remote add origin " + remote) |> ignore
 
         with 
-        | _ -> 
+        | e -> 
 
-            log.Error("Git could not be set up. Please try installing Git cli and run `arc git init`.")
+            log.Error($"Git could not be set up. Please try installing Git cli and run `arc git init`.\n\t{e}")
 
     /// Update the investigation file with the information from the other files and folders.
     let update (arcConfiguration : ArcConfiguration) =

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -46,7 +46,7 @@ module ArcAPI =
         ArcConfiguration.getRootFolderPaths arcConfiguration
         |> Array.iter (
             Directory.CreateDirectory 
-            >> fun dir -> File.Create(Path.Combine(dir.FullName, "README.md")) |> ignore 
+            >> fun dir -> File.Create(Path.Combine(dir.FullName, ".gitkeep")) |> ignore 
         )
 
         log.Trace("Set configuration")

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -69,10 +69,11 @@ module ArcAPI =
 
             Fake.Tools.Git.Repository.init workDir false true
 
-            let gitignoreAppPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".gitignore")
-            let gitignoreArcPath = Path.Combine(workDir, ".gitignore")
-            log.Trace($"Copy .gitignore from {gitignoreAppPath} to {gitignoreArcPath}")
-            File.Copy(gitignoreAppPath, gitignoreArcPath)
+            if containsFlag "Gitignore" arcArgs then
+                let gitignoreAppPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".gitignore")
+                let gitignoreArcPath = Path.Combine(workDir, ".gitignore")
+                log.Trace($"Copy .gitignore from {gitignoreAppPath} to {gitignoreArcPath}")
+                File.Copy(gitignoreAppPath, gitignoreArcPath)
 
             log.Trace("Add remote repository")
             match repositoryAdress with

--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -69,7 +69,7 @@ module AssayAPI =
             AssayConfiguration.getSubFolderPaths name arcConfiguration
             |> Array.iter (
                 Directory.CreateDirectory 
-                >> fun dir -> File.Create(Path.Combine(dir.FullName, "README.md")) |> ignore 
+                >> fun dir -> File.Create(Path.Combine(dir.FullName, ".gitkeep")) |> ignore 
             )
 
             AssayFile.create arcConfiguration assay name 

--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -67,7 +67,10 @@ module AssayAPI =
             log.Error($"Assay folder with identifier {name} already exists.")
         else
             AssayConfiguration.getSubFolderPaths name arcConfiguration
-            |> Array.iter (Directory.CreateDirectory >> ignore)
+            |> Array.iter (
+                Directory.CreateDirectory 
+                >> fun dir -> File.Create(Path.Combine(dir.FullName, "README.md")) |> ignore 
+            )
 
             AssayFile.create arcConfiguration assay name 
 

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <None Include="config_unix\config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="config_win\config" CopyToOutputDirectory="PreserveNewest" />
+    <None Include=".gitignore" CopyToOutputDirectory="PreserveNewest" />
     <Compile Include="Logging.fs" />
     <Compile Include="IniData.fs" />
     <Compile Include="ArcConfiguration.fs" />

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -9,6 +9,7 @@ type ArcInitArgs =
     | [<Unique>] RepositoryAdress of repository_adress : string
     | [<Unique>] EditorPath of editor_path : string
     | [<Unique>] GitLFSByteThreshold of git_lfs_threshold : string
+    | [<Unique>] Gitignore
 
     interface IArgParserTemplate with
         member this.Usage =
@@ -17,6 +18,7 @@ type ArcInitArgs =
             | RepositoryAdress _    ->  "Github adress"
             | EditorPath _          ->  "The path leading to the editor used for text prompts (Default in Windows is Notepad; Default in Unix systems is Nano)"
             | GitLFSByteThreshold _ ->  "The git LFS file size threshold in bytes. File larger than this threshold will be tracked by git LFS (Default Value is 150000000 Bytes ~ 150 MB)."
+            | Gitignore           _ ->  "Use this flag if you want a default .gitignore to be added to the initialized repo"
 
 type ArcExportArgs = 
 

--- a/src/ArcCommander/Logging.fs
+++ b/src/ArcCommander/Logging.fs
@@ -106,7 +106,7 @@ module Logging =
             printfn "%s" uMsg
         | true,false,false -> printfn "%s" exn.Message // exception message contains usage message but NO error message
         | false,false,true -> () // empty error message
-        | _ -> log.Error(exn.Message) // everything else will be a non-empty error message
+        | _ -> log.Error(exn) // everything else will be a non-empty error message
     
     /// Checks if a message (string) is empty and if it is not, applies a logging function to it.
     let checkNonLog s (logging : string -> unit) = if s <> "" then logging s

--- a/tests/ArcCommander.Tests.NetCore/ArcCommander/AssayTests.fs
+++ b/tests/ArcCommander.Tests.NetCore/ArcCommander/AssayTests.fs
@@ -103,7 +103,6 @@ let testAssayRegister =
             ]
             let testAssay = ISADotNet.XLSX.Assays.fromString measurementType "" "" "" "" "" "" assayFileName []
             
-            setupArc configuration
             processCommand configuration StudyAPI.register studyArgs
             processCommand configuration AssayAPI.init     assayInitArgs
             processCommand configuration AssayAPI.register assayRegisterArgs
@@ -344,7 +343,6 @@ let testAssayUpdate =
                 AssayAddArgs.TechnologyType "Assay3Tech"
             ]
             
-            setupArc configuration
             processCommand configuration AssayAPI.add assay1Args
             processCommand configuration AssayAPI.add assay2Args
             processCommand configuration AssayAPI.add assay3Args
@@ -469,7 +467,6 @@ let testAssayUnregister =
                 AssayUnregisterArgs.AssayIdentifier assayIdentifier
             ]
             
-            setupArc configuration
             processCommand configuration AssayAPI.add assay1Args
             processCommand configuration AssayAPI.add assay2Args
             processCommand configuration AssayAPI.add assay3Args
@@ -569,7 +566,6 @@ let testAssayMove =
                 AssayMoveArgs.TargetStudyIdentifier targetStudyIdentfier
             ]
             
-            setupArc configuration
             processCommand configuration AssayAPI.add assay1Args
             processCommand configuration AssayAPI.add assay2Args
             processCommand configuration AssayAPI.add assay3Args


### PR DESCRIPTION
Two `git-related` features were added to support the user in creating `arcs` following the specification:

#91

A standard `.gitignore` file gets added to the `arc` when `arc init` is called. This `.gitignore` by default will make `git` only track files inside the standard arc folders.

#92

Dummy `ReadMe.md` files will be added to `assay` subfolders (`dataset`,`protocols`). This will make `git` track these folders even if the user doesn't add any files themselves.