### PR TITLE
Arc sync can now push arc to previously non-existing gitlab repository

### DIFF
--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -35,7 +35,7 @@ module ArcAPI =
         let editor              = tryGetFieldValueByName "EditorPath"           arcArgs
         let gitLFSThreshold     = tryGetFieldValueByName "GitLFSByteThreshold"  arcArgs
         let branch              = tryGetFieldValueByName "Branch"               arcArgs |> Option.defaultValue "main"
-        let repositoryAddress    = tryGetFieldValueByName "RepositoryAddress"     arcArgs 
+        let repositoryAddress   = tryGetFieldValueByName "RepositoryAddress"     arcArgs 
 
 
         log.Trace("Create Directory")

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -34,7 +34,8 @@ module ArcAPI =
 
         let editor              = tryGetFieldValueByName "EditorPath"           arcArgs
         let gitLFSThreshold     = tryGetFieldValueByName "GitLFSByteThreshold"  arcArgs
-        let repositoryAdress    = tryGetFieldValueByName "RepositoryAdress"     arcArgs 
+        let branch              = tryGetFieldValueByName "Branch"               arcArgs |> Option.defaultValue "main"
+        let repositoryAddress    = tryGetFieldValueByName "RepositoryAddress"     arcArgs 
 
 
         log.Trace("Create Directory")
@@ -67,7 +68,9 @@ module ArcAPI =
 
         try
 
-            Fake.Tools.Git.Repository.init workDir false true
+            GitHelper.executeGitCommand workDir $"init -b {branch}"
+            //GitHelper.executeGitCommand workDir $"add ."
+            //GitHelper.executeGitCommand workDir $"commit -m \"Initial commit\""
 
             if containsFlag "Gitignore" arcArgs then
                 let gitignoreAppPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".gitignore")
@@ -76,10 +79,11 @@ module ArcAPI =
                 File.Copy(gitignoreAppPath, gitignoreArcPath)
 
             log.Trace("Add remote repository")
-            match repositoryAdress with
+            match repositoryAddress with
             | None -> ()
             | Some remote ->
-                GitHelper.executeGitCommand workDir ("remote add origin " + remote) |> ignore
+                GitHelper.executeGitCommand workDir $"remote add origin {remote}"
+                //GitHelper.executeGitCommand workDir $"branch -u origin/{branch} {branch}"
 
         with 
         | e -> 

--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -50,7 +50,7 @@ module GitAPI =
         log.Info("Start Arc Sync")
 
         // get repository directory
-        let repoDir = getRepoDir(arcConfiguration)
+        let repoDir = getRepoDir(arcConfiguration)     
 
         if checkUserMetadataConsistency repoDir log |> not then
 
@@ -131,32 +131,63 @@ module GitAPI =
 
             Fake.Tools.Git.Commit.exec repoDir commitMessage |> ignore
         
-            let branch = tryGetFieldValueByName "BranchName" gitArgs |> Option.defaultValue "main"
+            let branch = tryGetFieldValueByName "Branch" gitArgs |> Option.defaultValue "main"
 
             executeGitCommand repoDir $"branch -M {branch}" |> ignore
 
-            // detect existing remote
+            /// check whether a remote is set in git config
             let remoteSpecified () =
                 let ok, msg, error = Fake.Tools.Git.CommandHelper.runGitCommand repoDir "remote -v"
                 msg.Length > 0
+                            
+            /// check whether the specified remote exists online
+            let remoteExists () =
+                let ok, msg, error = Fake.Tools.Git.CommandHelper.runGitCommand repoDir "fetch"
+                error :: msg
+                |> List.exists (fun m -> 
+                    m.Contains "Repository not found"
+                    ||  m.Contains "The project you were looking for could not be found"
+                )
+                |> not
 
             // add remote if specified
-            match tryGetFieldValueByName "RepositoryAdress" gitArgs with
+            match tryGetFieldValueByName "RepositoryAddress" gitArgs with
                 | None -> ()
                 | Some remote ->
                     if remoteSpecified () then executeGitCommand repoDir ("remote remove origin") |> ignore
                     executeGitCommand repoDir ("remote add origin " + remote) |> ignore
 
-            if remoteSpecified() then log.Trace("Start syncing with remote")
-            else                log.Error("Can not sync with remote as no remote repository adress was specified.")
+            // pull and push if remote exists
+            if remoteSpecified() then
 
-            // pull if remote exists
-            if hasRemote() then
-                log.Trace("Pull")
-                executeGitCommand repoDir ("fetch origin") |> ignore
-                executeGitCommand repoDir ($"pull --rebase origin {branch}") |> ignore
+                log.Trace("Start syncing with remote")
 
-            // push if remote exists
-            if hasRemote () then
-                log.Trace("Push")
-                executeGitCommand repoDir ($"push -u origin {branch}") |> ignore
+                if remoteExists() then
+                    log.Trace("Pull")
+                    executeGitCommand repoDir ("fetch origin") |> ignore
+                    executeGitCommand repoDir ($"pull --rebase origin {branch}") |> ignore
+
+                    log.Trace("Push")
+                    executeGitCommand repoDir ($"push -u origin {branch}") |> ignore
+
+                else
+
+                    if containsFlag "Force" gitArgs then
+
+                        log.Trace("Remote does not exist and --force flag was set. Trying to create upstream repo.")
+
+                        executeGitCommand repoDir ($"push --set-upstream origin {branch}") |> ignore
+
+                    else
+                        let m = 
+                            [
+                                "Remote repo was set, but does not exist."
+                                "Check whether it was spelled correctly. If not, you can run \"arc sync\" again using the --repositoryAddress argument."
+                                "If you want to create a new remote repository instead. You can run \"arc sync -f\" to force push the local repository to a new upstream."
+                            ]
+                            |> List.reduce (fun a b -> a + "\n" + b)
+                        log.Error(m)
+
+            else
+
+                log.Error("Can not sync with remote as no remote repository adress was specified.")

--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -136,7 +136,7 @@ module GitAPI =
             executeGitCommand repoDir $"branch -M {branch}" |> ignore
 
             // detect existing remote
-            let hasRemote () =
+            let remoteSpecified () =
                 let ok, msg, error = Fake.Tools.Git.CommandHelper.runGitCommand repoDir "remote -v"
                 msg.Length > 0
 
@@ -144,10 +144,10 @@ module GitAPI =
             match tryGetFieldValueByName "RepositoryAdress" gitArgs with
                 | None -> ()
                 | Some remote ->
-                    if hasRemote () then executeGitCommand repoDir ("remote remove origin") |> ignore
+                    if remoteSpecified () then executeGitCommand repoDir ("remote remove origin") |> ignore
                     executeGitCommand repoDir ("remote add origin " + remote) |> ignore
 
-            if hasRemote() then log.Trace("Start syncing with remote" )
+            if remoteSpecified() then log.Trace("Start syncing with remote")
             else                log.Error("Can not sync with remote as no remote repository adress was specified.")
 
             // pull if remote exists

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -6,7 +6,9 @@ open Argu
 type ArcInitArgs = 
 
     | [<Unique>] Owner of owner : string
-    | [<Unique>] RepositoryAdress of repository_adress : string
+    | [<Unique>] Branch of branch_name : string
+    // --repositoryadress is obsolete (previous spelling mistake)
+    | [<AltCommandLine("--repositoryadress")>][<AltCommandLine("--remote")>][<Unique>] RepositoryAddress of repository_address : string
     | [<Unique>] EditorPath of editor_path : string
     | [<Unique>] GitLFSByteThreshold of git_lfs_threshold : string
     | [<Unique>] Gitignore
@@ -14,9 +16,10 @@ type ArcInitArgs =
     interface IArgParserTemplate with
         member this.Usage =
             match this with
-            | Owner _               ->  "Owner of the ARC"
-            | RepositoryAdress _    ->  "Github adress"
-            | EditorPath _          ->  "The path leading to the editor used for text prompts (Default in Windows is Notepad; Default in Unix systems is Nano)"
+            | Owner               _ ->  "Owner of the ARC"
+            | Branch              _ ->  "Name of the git branch to be created"
+            | RepositoryAddress   _ ->  "Github address"
+            | EditorPath          _ ->  "The path leading to the editor used for text prompts (Default in Windows is Notepad; Default in Unix systems is Nano)"
             | GitLFSByteThreshold _ ->  "The git LFS file size threshold in bytes. File larger than this threshold will be tracked by git LFS (Default Value is 150000000 Bytes ~ 150 MB)."
             | Gitignore           _ ->  "Use this flag if you want a default .gitignore to be added to the initialized repo"
 

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -6,9 +6,9 @@ open Argu
 type ArcInitArgs = 
 
     | [<Unique>] Owner of owner : string
-    | [<Unique>] Branch of branch_name : string
+    | [<AltCommandLine("-b")>][<Unique>] Branch of branch_name : string
     // --repositoryadress is obsolete (previous spelling mistake)
-    | [<AltCommandLine("--repositoryadress")>][<AltCommandLine("--remote")>][<Unique>] RepositoryAddress of repository_address : string
+    | [<AltCommandLine("--repositoryadress")>][<AltCommandLine("-r")>][<Unique>] RepositoryAddress of repository_address : string
     | [<Unique>] EditorPath of editor_path : string
     | [<Unique>] GitLFSByteThreshold of git_lfs_threshold : string
     | [<Unique>] Gitignore
@@ -39,14 +39,17 @@ type ArcExportArgs =
 type ArcSyncArgs =
     | [<Unique>][<AltCommandLine("-r")>] RepositoryAddress  of repository_address:string
     | [<Unique>][<AltCommandLine("-m")>] CommitMessage      of commit_message:string
-    | [<Unique>][<AltCommandLine("-b")>] BranchName         of branch_name:string
+    | [<Unique>][<AltCommandLine("-b")>] Branch             of branch:string
+    | [<Unique>][<AltCommandLine("-f")>] Force
+
 
     interface IArgParserTemplate with
         member this.Usage =
             match this with
-            | RepositoryAddress _   -> "Git remote address with which to sync the ARC. If no address is either given here or set previously when initing or getting the ARC, changes are only committed but not synced."
-            | CommitMessage _       -> "Descriptive title for the changes made (e.g. add new assay). If none is given, default commit message is used."
-            | BranchName _          -> "Name of the branch to which the changes should be pushed. If none is given, defaults to \"main\""
+            | RepositoryAddress _ -> "Git remote address with which to sync the ARC. If no address is either given here or set previously when initing or getting the ARC, changes are only committed but not synced."
+            | CommitMessage     _ -> "Descriptive title for the changes made (e.g. add new assay). If none is given, default commit message is used."
+            | Branch            _ -> "Name of the branch to which the changes should be pushed. If none is given, defaults to \"main\""
+            | Force             _ -> "When a remote is set, but does not exist online, tries to create it."
 
 /// TO-DO: Argumente anpassen
 type ArcGetArgs =

--- a/src/ArcCommander/GitHelper.fs
+++ b/src/ArcCommander/GitHelper.fs
@@ -27,6 +27,7 @@ module GitHelper =
                 elif args.Data.ToLower().Contains ("trace") then
                     log.Trace($"GIT: {args.Data}")   
                 else
+                    outputs.Add(args.Data)
                     log.Info($"GIT: {args.Data}")
         
         let errorHandler (_sender:obj) (args:DataReceivedEventArgs) =  
@@ -37,6 +38,7 @@ module GitHelper =
                 elif msg.Contains ("trace") then
                     log.Trace($"GIT: {args.Data}")   
                 else
+                    outputs.Add(args.Data)
                     log.Info($"GIT: {args.Data}")
         
         let p = new Process(StartInfo = procStartInfo)

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -164,7 +164,11 @@ module IniData =
 
     /// If the given key exists in the section (keyData) return its value
     let tryGetValue key (keydData : KeyDataCollection) =
-        try keydData.Item key |> Some with | _ -> None
+        try 
+            let v = keydData.Item key 
+            if v = null then None
+            else Some v
+        with | _ -> None
 
 
     /// Any given key can be placed once per section.


### PR DESCRIPTION
If a `remote repository` was specified when `iniating` the `arc` or running `arc sync`, the `ArcCommander` tries to `fetch` and `push` from and to this repository.

Now the `ArcCommander` checks whether this remote does actually exist. If not, it throws the followign error: 
![image](https://user-images.githubusercontent.com/17880410/156790623-7b505883-2f08-4807-aee8-bc4efdc22ad7.png)

Using the `arc sync -f`, the `ArcCommander` now instead tries to directly push the changes to the remote server. Creating a new remote repository. This only works for `Gitlab`, and not for `GitHub`.