### PR TITLE
Extent studies, replace `externals` folder

### DIFF
--- a/src/ArcCommander/.gitignore
+++ b/src/ArcCommander/.gitignore
@@ -8,7 +8,7 @@
 !.arc/**
 !assays/
 !assays/**
-!stduy/
+!study/
 !study/**
 !workflows/
 !workflows/**

--- a/src/ArcCommander/.gitignore
+++ b/src/ArcCommander/.gitignore
@@ -8,8 +8,8 @@
 !.arc/**
 !assays/
 !assays/**
-!externals/
-!externals/**
+!stduy/
+!study/**
 !workflows/
 !workflows/**
 !runs/

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -23,7 +23,7 @@ module ArcAPI =
         log.Debug($"v{ver.Major}.{ver.Minor}.{ver.Build}")
 
     // TODO TO-DO TO DO: make use of args
-    /// Initializes the arc specific folder structure.
+    /// Initializes the ARC-specific folder structure.
     let init (arcConfiguration : ArcConfiguration) (arcArgs : Map<string,Argument>) =
 
         let log = Logging.createLogger "ArcInitLog"
@@ -35,7 +35,7 @@ module ArcAPI =
         let editor              = tryGetFieldValueByName "EditorPath"           arcArgs
         let gitLFSThreshold     = tryGetFieldValueByName "GitLFSByteThreshold"  arcArgs
         let branch              = tryGetFieldValueByName "Branch"               arcArgs |> Option.defaultValue "main"
-        let repositoryAddress   = tryGetFieldValueByName "RepositoryAddress"     arcArgs 
+        let repositoryAddress   = tryGetFieldValueByName "RepositoryAddress"    arcArgs 
 
 
         log.Trace("Create Directory")
@@ -135,7 +135,7 @@ module ArcAPI =
                     | None ->
                         Study.fromParts (Study.StudyInfo.create a "" "" "" "" "" []) [] [] factors [assay] protocols persons
                         |> API.Study.add studies
-                | None ->                   
+                | None ->
                     [Study.fromParts (Study.StudyInfo.create a "" "" "" "" "" []) [] [] factors [assay] protocols persons]
                 |> API.Investigation.setStudies investigation
                 |> updateInvestigationAssays t

--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -34,7 +34,7 @@ module AssayAPI =
         /// Creates an assay file from the given assay in the ARC.
         let create (arcConfiguration : ArcConfiguration) (assay) (identifier : string) =
             IsaModelConfiguration.getAssayFilePath identifier arcConfiguration
-            |> ISADotNet.XLSX.AssayFile.Assay.init "Investigation" (Some assay) None identifier
+            |> ISADotNet.XLSX.AssayFile.Assay.init (Some assay) None identifier
 
     /// Initializes a new empty assay file and associated folder structure in the ARC.
     let init (arcConfiguration : ArcConfiguration) (assayArgs : Map<string,Argument>) =
@@ -109,7 +109,7 @@ module AssayAPI =
             match getFieldValueByName "StudyIdentifier" assayArgs with
             | "" -> assayIdentifier
             | s -> 
-                log.Trace("No Study Identifier given, use assayIdentifier instead.")
+                log.Trace("No Study Identifier given, use Assay Identifier instead.")
                 s
 
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
@@ -122,7 +122,7 @@ module AssayAPI =
 
         // part that writes assay metadata into the assay file
         try 
-            MetaData.overwriteWithAssayInfo "Investigation" assay doc
+            MetaData.overwriteWithAssayInfo "Assay" assay doc
             
         finally
             Spreadsheet.close doc
@@ -285,7 +285,7 @@ module AssayAPI =
         let investigationFilePath = IsaModelConfiguration.tryGetInvestigationFilePath arcConfiguration |> Option.get
 
         let investigation = Investigation.fromFile investigationFilePath
-                
+
         match investigation.Studies with
         | Some studies -> 
             match API.Study.tryGetByIdentifier studyIdentifier studies with
@@ -305,14 +305,14 @@ module AssayAPI =
             | None ->
                 log.Info($"Study with the identifier {studyIdentifier} does not exist yet, creating it now.")
                 if StudyAPI.StudyFile.exists arcConfiguration studyIdentifier |> not then
-                    StudyAPI.StudyFile.create arcConfiguration studyIdentifier
+                    StudyAPI.StudyFile.create arcConfiguration (Study.create(Identifier = studyIdentifier)) studyIdentifier
                 let info = Study.StudyInfo.create studyIdentifier "" "" "" "" "" []
                 Study.fromParts info [] [] [] [assay] [] []
                 |> API.Study.add studies
         | None ->
             log.Info($"Study with the identifier {studyIdentifier} does not exist yet, creating it now.")
             if StudyAPI.StudyFile.exists arcConfiguration studyIdentifier |> not then
-                StudyAPI.StudyFile.create arcConfiguration studyIdentifier
+                StudyAPI.StudyFile.create arcConfiguration (Study.create(Identifier = studyIdentifier)) studyIdentifier
             let info = Study.StudyInfo.create studyIdentifier "" "" "" "" "" []
             [Study.fromParts info [] [] [] [assay] [] []]
         |> API.Investigation.setStudies investigation

--- a/src/ArcCommander/APIs/ExternalExecutables.fs
+++ b/src/ArcCommander/APIs/ExternalExecutables.fs
@@ -33,7 +33,7 @@ module ExternalExecutables =
     let getArcFoldersForExtExe root = // arc folder: .arc, root, study 
         let stdFolders =
             root :: (
-                ["study"; ".arc"]
+                [".arc"; "studies"]
                 |> List.map (fun p -> Path.Combine(root, p))
             )
         let studySubFolders = Directory.GetDirectories(List.last stdFolders, "*", searchOption = SearchOption.AllDirectories) |> List.ofArray

--- a/src/ArcCommander/APIs/ExternalExecutables.fs
+++ b/src/ArcCommander/APIs/ExternalExecutables.fs
@@ -30,11 +30,14 @@ module ExternalExecutables =
         |> Array.reduce (fun a b -> a + "-" + b)
 
     /// Returns ARC folders where an external executable might be present.
-    let getArcFoldersForExtExe root = // arc folder: Externals, .arc, root; 
-        root :: (
-            ["externals"; ".arc"]
-            |> List.map (fun p -> Path.Combine(root, p))
-        )
+    let getArcFoldersForExtExe root = // arc folder: .arc, root, study 
+        let stdFolders =
+            root :: (
+                ["study"; ".arc"]
+                |> List.map (fun p -> Path.Combine(root, p))
+            )
+        let studySubFolders = Directory.GetDirectories(List.last stdFolders, "*", searchOption = SearchOption.AllDirectories) |> List.ofArray
+        List.append stdFolders studySubFolders
 
     /// Adds a extra directory to the PATH variable.
     let addExtraDirToPath os extraDir =

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -53,7 +53,7 @@ module StudyAPI =
 
             Directory.CreateDirectory studyFolderPath |> ignore
 
-            StudyFile.Study.init (Some study) "(noAssayAssociated)" studyFilePath
+            StudyFile.Study.init (Some study) studyIdentifier studyFilePath
 
 
     /// Initializes a new empty study file in the ARC.

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -32,7 +32,7 @@ module StudyAPI =
             match fileExists, folderExists with
             | true, _ -> true
             | false, true ->
-                log.Trace "Study file cannot be found in study folder."
+                log.Trace "Study file cannot be found in the study's folder."
                 false
             | _ ->
                 log.Trace "Study file and folder can not be found."

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -66,8 +66,8 @@
     <PackageReference Include="FSharpSpreadsheetML" Version="0.0.8" />
     <PackageReference Include="IdentityModel.OidcClient" Version="5.0.0" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="ISADotNet" Version="0.4.0-preview.4" />
-    <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.4" />
+    <PackageReference Include="ISADotNet" Version="0.4.0-preview.5" />
+    <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.5" />
     <PackageReference Include="JWT" Version="8.9.0" />
     <PackageReference Include="Microsoft.Net.Http.Server" Version="1.1.4" />
     <PackageReference Include="NLog" Version="4.7.13" />

--- a/src/ArcCommander/ArcConfiguration.fs
+++ b/src/ArcCommander/ArcConfiguration.fs
@@ -11,18 +11,18 @@ type ArcConfiguration =
         IsaModel    : Map<string,string>
         Assay       : Map<string,string>
         Workflow    : Map<string,string>
-        External    : Map<string,string>
+        Study     : Map<string,string>
         Run         : Map<string,string>
     }
 
     /// Creates an ArcConfiguration from the section settings.
-    static member create general isaModel assay workflow external run =
+    static member create general isaModel assay workflow study run =
         {
             General     = general
             IsaModel    = isaModel
             Assay       = assay
             Workflow    = workflow
-            External    = external 
+            Study       = study
             Run         = run
         }
 
@@ -44,7 +44,7 @@ type ArcConfiguration =
         "general.forceeditor"               , "false"
         
         "isamodel.investigationfilename"    , "isa.investigation.xlsx"
-        "isamodel.studiesfilename"          , "isa.studies.xlsx"
+        "isamodel.studyfilename"            , "isa.study.xlsx"
         "isamodel.assay location"           , "folder.assay.rootfolder"
         "isamodel.assayfilename"            , "isa.assay.xlsx"
         
@@ -56,8 +56,8 @@ type ArcConfiguration =
         "workflow.rootfolder"               , "workflows"
         "workflow.dockerfile"               , "Dockerfile"
         
-        "external.rootfolder"               , "externals"
-        "external.externalsfile"            , "isa.tab"
+        "study.rootfolder"                  , "studies"
+        "study.file"                        , "README.md"
         
         "run.rootfolder"                    , "runs"
         ]
@@ -71,7 +71,7 @@ type ArcConfiguration =
             (getSectionMap "isamodel"  argumentConfig)
             (getSectionMap "assay"     argumentConfig)
             (getSectionMap "workflow"  argumentConfig)
-            (getSectionMap "external"  argumentConfig)
+            (getSectionMap "study"     argumentConfig)
             (getSectionMap "run"       argumentConfig)
 
     /// Gets the current configuration by merging the default settings, the global settings, the local settings and the settings given through arguments. Uses `ofIniData`for this.
@@ -97,7 +97,7 @@ type ArcConfiguration =
         [|
             configuration.General.TryFind "rootfolder"
             configuration.Assay.TryFind "rootfolder"
-            configuration.External.TryFind "rootfolder"
+            configuration.Study.TryFind "rootfolder"
             configuration.IsaModel.TryFind "rootfolder"
             configuration.Run.TryFind "rootfolder"
             configuration.Workflow.TryFind "rootfolder"
@@ -111,7 +111,7 @@ type ArcConfiguration =
         [|
             configuration.General |> Map.map (keyValueToNameValue "general")
             configuration.Assay |> Map.map (keyValueToNameValue "assay")
-            configuration.External |> Map.map (keyValueToNameValue "external")
+            configuration.Study |> Map.map (keyValueToNameValue "study")
             configuration.IsaModel |> Map.map (keyValueToNameValue "isamodel")
             configuration.Run |> Map.map (keyValueToNameValue "run")
             configuration.Workflow |> Map.map (keyValueToNameValue "workflow")
@@ -244,28 +244,31 @@ module IsaModelConfiguration =
         |> Option.get
 
     /// Returns the name of the study's file if it exists. Else returns None.
-    let tryGetStudiesFileName identifier (configuration : ArcConfiguration) =
-        //Map.tryFind "studiesfilename" configuration.IsaModel
-        sprintf "%s_isa.study.xlsx" identifier
-        |> Some
+    let tryGetStudyFileName identifier (configuration : ArcConfiguration) =
+        let studyFilename = Map.tryFind "studyfilename" configuration.IsaModel
+        match studyFilename with
+        | Some f ->
+            Path.Combine(identifier, f)
+            |> Some
+        | _ -> None
 
     /// Returns the name of the study's file.
-    let getStudiesFileName identifier (configuration : ArcConfiguration) =
-        tryGetStudiesFileName identifier configuration
+    let getStudyFileName identifier (configuration : ArcConfiguration) =
+        tryGetStudyFileName identifier configuration
         |> Option.get 
 
     /// Returns the full path of the study's file if it exists. Else returns None.
-    let tryGetStudiesFilePath identifier (configuration : ArcConfiguration) =
+    let tryGetStudyFilePath identifier (configuration : ArcConfiguration) =
         let workDir = Map.find "workdir" configuration.General
-        match tryGetStudiesFileName identifier configuration with
+        match tryGetStudyFileName identifier configuration with
         | Some i -> 
-            Path.Combine(workDir, i)
+            Path.Combine(workDir, "studies", i)
             |> Some
         | _ -> None
       
     /// Returns the full path of the study's file.
-    let getStudiesFilePath identifier (configuration : ArcConfiguration) =
-        tryGetStudiesFilePath identifier configuration
+    let getStudyFilePath identifier (configuration : ArcConfiguration) =
+        tryGetStudyFilePath identifier configuration
         |> Option.get
 
     /// Returns the full path of the study files located in the arc root folder.

--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -55,7 +55,7 @@ module ArgumentProcessing =
 
     /// Returns the value given by the user for name k.
     let getFieldValueByName k (arguments : Map<string,Argument>) = 
-        let log = Logging.createLogger "ArgumentProcessingGetFieldByValueLog"
+        let log = Logging.createLogger "ArgumentProcessingGetFieldValueByNameLog"
         match Map.find k arguments with
         | Field v -> v
         | Flag -> 

--- a/src/ArcCommander/CLIArguments/StudyArgs.fs
+++ b/src/ArcCommander/CLIArguments/StudyArgs.fs
@@ -2,8 +2,8 @@
 
 open Argu 
 
-/// CLI arguments for empty study initialization
-type StudyInitArgs =
+/// CLI arguments for interactively editing existing study metadata 
+type StudyEditArgs =
     | [<Mandatory>][<AltCommandLine("-s")>][<Unique>] Identifier of study_identifier : string
 
     interface IArgParserTemplate with
@@ -33,10 +33,6 @@ type StudyUpdateArgs =
             | AddIfMissing              _ -> "If this flag is set, a new study will be registered with the given parameters, if it did not previously exist"
 
 
-/// CLI arguments for interactively editing existing study metadata 
-// Same arguments as `init` because the study can be identified just by the identifier
-type StudyEditArgs = StudyInitArgs
-
 /// CLI arguments for registering existing study metadata 
 type StudyRegisterArgs = 
     | [<Mandatory>][<AltCommandLine("-s")>][<Unique>] Identifier of study_identifier : string
@@ -53,6 +49,10 @@ type StudyRegisterArgs =
             | Description _->   "A textual description of the study, with components such as objective or goals"
             | SubmissionDate _->   "The date on which the study is submitted to an archive"
             | PublicReleaseDate _->   "The date on which the study SHOULD be released publicly"
+
+// Same arguments as `init` because the study can be identified just by the identifier
+/// CLI arguments for empty study initialization
+type StudyInitArgs = StudyRegisterArgs
 
 /// CLI arguments for initializing and subsequently registering study metadata 
 // Same arguments as `update` because all metadata fields that can be updated can also be set while registering a new assay

--- a/src/ArcCommander/Commands/StudyCommand.fs
+++ b/src/ArcCommander/Commands/StudyCommand.fs
@@ -40,7 +40,7 @@ type StudyCommand =
             | Add           _ -> "Create a new study file in the ARC and subsequently register it with the given study metadata"
             | Delete        _ -> "Delete a study from the ARC file structure"
             | Unregister    _ -> "Unregister a study from the ARC investigation file"
-            | Remove        _ -> "Remove a study from the ARC"
+            | Remove        _ -> "Remove a study from the ARC (delete the study and unregister it from the investigation file)"
             | Update        _ -> "Update an existing study in the ARC with the given study metadata"
             | Edit          _ -> "Open and edit an existing study in the ARC with a text editor. Arguments passed for this command will be pre-set in the editor."
             | Show          _ -> "Get the values of a study"

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -251,9 +251,8 @@ let main argv =
         
         let arcCommanderDataFolder = IniData.createDataFolder ()
         let arcDataFolder = 
-            let adfp = tryGetArcDataFolderPath workingDir arcCommanderDataFolder
-            if adfp.IsSome then adfp.Value
-            else arcCommanderDataFolder
+            tryGetArcDataFolderPath workingDir arcCommanderDataFolder
+            |> Option.defaultValue arcCommanderDataFolder
         Logging.generateConfig arcDataFolder (GeneralConfiguration.getVerbosity arcConfiguration)
         let log = Logging.createLogger "ArcCommanderMainLog"
 
@@ -284,9 +283,8 @@ let main argv =
         try
             let arcCommanderDataFolder = IniData.createDataFolder ()
             let arcDataFolder = 
-                let adfp = tryGetArcDataFolderPath currDir arcCommanderDataFolder
-                if adfp.IsSome then adfp.Value
-                else arcCommanderDataFolder
+                tryGetArcDataFolderPath currDir arcCommanderDataFolder
+                |> Option.defaultValue arcCommanderDataFolder
             Logging.generateConfig arcDataFolder 0
 
         // create logging config, create .arc folder if not already existing:

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -257,6 +257,8 @@ let main argv =
         Logging.generateConfig arcDataFolder (GeneralConfiguration.getVerbosity arcConfiguration)
         let log = Logging.createLogger "ArcCommanderMainLog"
 
+        log.Trace("Start ArcCommander")
+
         // Try parse the command line arguments
         let parseResults = tryExecuteExternalTool log parser argv workingDir
 

--- a/src/ArcCommander/config_unix/config
+++ b/src/ArcCommander/config_unix/config
@@ -11,7 +11,7 @@ forceeditor=false
 
 [isamodel]
 investigationfilename=isa.investigation.xlsx
-studiesfilename=isa.studies.xlsx
+studyfilename=isa.study.xlsx
 # assay location=folder.assay.rootfolder
 assayfilename=isa.assay.xlsx
 
@@ -25,9 +25,9 @@ files=README.md
 rootfolder=workflows
 dockerfile=Dockerfile
 
-[external]
-rootfolder=externals
-externalsfile=isa.tab
+[study]
+rootfolder=studies
+studyfile=README.md
 
 [run]
 rootfolder=runs

--- a/src/ArcCommander/config_win/config
+++ b/src/ArcCommander/config_win/config
@@ -11,7 +11,7 @@ forceeditor=false
 
 [isamodel]
 investigationfilename=isa.investigation.xlsx
-studiesfilename=isa.studies.xlsx
+studyfilename=isa.study.xlsx
 # assay location=folder.assay.rootfolder
 assayfilename=isa.assay.xlsx
 
@@ -25,9 +25,9 @@ files=README.md
 rootfolder=workflows
 dockerfile=Dockerfile
 
-[external]
-rootfolder=externals
-externalsfile=isa.tab
+[study]
+rootfolder=studies
+studyfile=README.md
 
 [run]
 rootfolder=runs

--- a/tests/ArcCommander.Tests.NetCore/ArcCommander.Tests.NetCore.fsproj
+++ b/tests/ArcCommander.Tests.NetCore/ArcCommander.Tests.NetCore.fsproj
@@ -23,8 +23,8 @@
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="FSharpSpreadsheetML" Version="0.0.8" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="ISADotNet" Version="0.4.0-preview.4" />
-    <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.4" />
+    <PackageReference Include="ISADotNet" Version="0.4.0-preview.5" />
+    <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.5" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="ArcCommander\TestFiles\" />

--- a/tests/ArcCommander.Tests.NetCore/ArcCommander/AssayTests.fs
+++ b/tests/ArcCommander.Tests.NetCore/ArcCommander/AssayTests.fs
@@ -25,7 +25,7 @@ let processCommand (arcConfiguration : ArcConfiguration) commandF (r : 'T list w
     Prompt.deannotateArguments g 
     |> commandF arcConfiguration
 
-let setupArc (arcConfiguration:ArcConfiguration) =
+let setupArc (arcConfiguration : ArcConfiguration) =
     let investigationArgs = [InvestigationCreateArgs.Identifier "TestInvestigation"]
     let arcArgs : ArcInitArgs list = [] 
 
@@ -59,7 +59,7 @@ let testAssayTestFunction =
         )
         testCase "ListsCorrectAssaysInCorrectStudies" (fun () -> 
             let testAssays = [
-                "BII-S-1",["a_proteome.txt";"a_metabolome.txt";"a_transcriptome.txt"]
+                "BII-S-1",["a_proteome.txt";"a_metabolome.txt"; "a_transcriptome.txt"]
                 "BII-S-2",["a_microarray.txt"]
             ]
             let investigation = ISADotNet.XLSX.Investigation.fromFile investigationFilePath
@@ -371,7 +371,7 @@ let testAssayUpdate =
 
             let assay = study.Assays.Value.[1]
 
-            Expect.equal assay.FileName testAssay.FileName "Assay Filename has changed even though it shouldnt"
+            Expect.equal assay.FileName testAssay.FileName "Assay Filename has changed even though it shouldn't"
             Expect.equal assay.TechnologyType testAssay.TechnologyType "Assay technology type has changed, even though no value was given and the \"ReplaceWithEmptyValues\" flag was not set"
             Expect.equal assay.MeasurementType testAssay.MeasurementType "Assay Measurement type was not updated correctly"
 

--- a/tests/ArcCommander.Tests.NetCore/ArcCommander/StudyTests.fs
+++ b/tests/ArcCommander.Tests.NetCore/ArcCommander/StudyTests.fs
@@ -12,7 +12,7 @@ let standardISAArgs =
     Map.ofList 
         [
             "investigationfilename","isa.investigation.xlsx";
-            "studiesfilename","isa.study.xlsx";
+            "studyfilename","isa.study.xlsx";
             "assayfilename","isa.assay.xlsx"
         ]
 
@@ -63,8 +63,8 @@ let testStudyProtocolLoad =
 
     let configuration = 
         ArcConfiguration.create 
-            (Map.ofList ["workdir",testDirectory;"verbosity","2";"editor","Decoy"]) 
-            (standardISAArgs)
+            (Map.ofList ["workdir", testDirectory; "verbosity", "2"; "editor", "Decoy"]) 
+            standardISAArgs
             Map.empty Map.empty Map.empty Map.empty
 
     testList "StudyProtocolLoadTests" [
@@ -79,7 +79,7 @@ let testStudyProtocolLoad =
             
             let testProtocolName = "peptide_digestion"
             let testProtocolTypeName = AnnotationValue.Text "Protein Digestion"
-                        
+
             setupArc configuration
             processCommand configuration StudyAPI.register studyArgs
             processCommand configuration StudyAPI.Protocols.load loadArgs
@@ -90,7 +90,7 @@ let testStudyProtocolLoad =
                 let protocols = study.Protocols
                 Expect.isSome protocols "Protocol was not added, as Protocols is still None"
                 let protocol = API.Protocol.tryGetByName testProtocolName protocols.Value
-                Expect.isSome protocol "Protocol could not be found, either it was no added or the name was not inserted correctly"
+                Expect.isSome protocol "Protocol could not be found, either it was not added or the name was not inserted correctly"
                 let protocolType = protocol.Value.ProtocolType
                 Expect.isSome protocolType "ProtocolType was not added to protocol"
                 Expect.equal protocolType.Value.Name.Value testProtocolTypeName "ProtocolType name field was not correctly transferred from protocol file"


### PR DESCRIPTION
- IsaDotNet dependency was updated to v0.0.4-preview.5
- `externals` folder is now `studies` folder
- `studies` folder now holds all studies
- Every study has its own study folder, named by the study's name
- Study files now all have the fixed name "isa.study.xlsx"
- All functions, methods, and files (configs, .gitignore) and folders were adjusted accordingly
- Unit tests were updated, too
- A (minor) logging error has been fixed
- Some typos fixed
- Some phrasing unified

__IMPORTANT:__ What's missing: Changes _do not_ apply to `arc s edit` and `arc s update`. Both functions have to be updated later.