### PR TITLE
update hard-coded links to arc mac/linux assests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We strongly recommend to read the in-depth guide to the ArcCommander in this rep
 1. Download the latest ArcCommander release
 
     ```bash
-    wget https://github.com/nfdi4plants/arcCommander/releases/download/v0.3.1-linux.x64/arc
+    wget https://github.com/nfdi4plants/arcCommander/releases/download/v0.3.2-linux.x64/arc
     ```
 
 1. Make it executable
@@ -66,7 +66,7 @@ You should see the following or similar message:
 
 > Start processing parameterless command.  
 > Start Arc Version  
-> v0.3.1
+> v0.3.2
 > Done processing command.  
 
 ### MacOS
@@ -75,7 +75,8 @@ You should see the following or similar message:
 2. Copy/paste the following commands into your terminal and execute them to (a) download the latest ArcCommander release, (b) change permissions to make the arcCommander executable and (c) move the arcCommander program to a location from where it is executable via the terminal:
 
     ```bash
-    curl -L https://github.com/nfdi4plants/arcCommander/releases/download/v0.3.1-osx.x64/arc > arc
+    
+    curl -L https://github.com/nfdi4plants/arcCommander/releases/download/v0.3.2-osx.x64/arc > arc
     chmod u+x ./arc
     mv ./arc /usr/local/bin/
     ```
@@ -111,7 +112,7 @@ You should see the following or similar message:
 
 > Start processing parameterless command.  
 > Start Arc Version  
-> v0.3.1
+> v0.3.2
 > Done processing command.  
 
 ---


### PR DESCRIPTION
I'm sure there's a better way (than manually updating with every release). Just keeping this alive to make it user-friendly. 