### PR TITLE
Add file name attribute

### DIFF
--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -254,10 +254,10 @@ module ArgumentProcessing =
         ///
         /// Also checks for forbidden characters, reserved file names, and spaces if the key concerns file names.
         let private splitAtFirst (c : char) (s : string) =
-            let checkValue key (valu : string) = 
+            let checkValue (key : string) (valu : string) = 
                 valu.Trim()
                 |> fun trValu ->
-                    if key = "Identifier" then
+                    if key.Contains "Identifier" then
                         iterForbiddenChars trValu
                         checkForReservedFns trValu
                         replaceSpace trValu
@@ -301,7 +301,8 @@ module ArgumentProcessing =
             with
             | err -> 
                 delete filePath
-                log.Fatal($"Could not parse query:\n {err.ToString()}")
+                log.Fatal($"Could not parse query.")
+                log.Trace($"{err.ToString()}")
                 raise (Exception(""))
 
         /// Opens a textprompt containing the result of the serialized input parameters. Returns the deserialized user input.

--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -38,6 +38,45 @@ module ArgumentProcessing =
             IsFlag = isFlag
         }
 
+    /// Characters that must not occur in file names.
+    let private forbiddenChars = 
+        // classic forbidden symbols for file names in Windows (which also includes Linux/macOS)
+        let forbiddenSymbols = [|'/'; '\\'; '"'; '>'; '<'; '?'; '='; '*'; '|'|]
+        let controlChars = Array.init 32 (fun i -> char i)
+        Array.append controlChars forbiddenSymbols
+
+    /// File names that are reserved in Windows and thus cannot be used by the user.
+    let private reservedFilenames = [|
+            "CON"; "PRN"; "AUX"; "NUL";
+            for i = 1 to 9 do
+                $"COM{i}"
+                $"LPT{i}"
+        |]
+
+    /// Takes a string and iterates through all characters, checking for forbidden chars.
+    let private iterForbiddenChars (str : string) =
+        let log = Logging.createLogger "ArgumentProcessingIterForbiddenCharsLog"
+        forbiddenChars
+        |> Array.iter (
+            fun fc -> 
+                if str.Contains fc then
+                    log.Error $"Symbol/letter \"{fc}\" is not permitted for identifiers/filenames. Please choose another one."
+                    raise (Exception "")
+        )
+
+    /// Takes a string a replaces all spaces with underscores.
+    let private replaceSpace (str : string) =
+        let log = Logging.createLogger "ArgumentProcessingReplaceSpaceLog"
+        if str.Contains ' ' then log.Warn $"Identifier/filename \"{str}\" contains one or several space(s). Replaced with underscore(s)."
+        str.Replace(' ', '_')
+
+    /// Takes a string and checks if it is a reserved file name.
+    let private checkForReservedFns str =
+        let log = Logging.createLogger "ArgumentProcessingCheckForReservedFnsLog"
+        if reservedFilenames |> Array.contains str then
+            log.Error $"Identifier/filename \"{str}\" is a reserved filename. Please choose another one."
+            raise (Exception "")
+
     /// Returns true if the argument flag of name k was given by the user.
     let containsFlag k (arguments : Map<string,Argument>) =
         let log = Logging.createLogger "ArgumentProcessingContainsFlagLog"
@@ -92,7 +131,6 @@ module ArgumentProcessing =
     /// Adds all union cases of 'T which are missing to the list.
     let groupArguments (args : 'T list when 'T :> IArgParserTemplate) =
         let log = Logging.createLogger "ArgumentProcessingGroupArgumentsLog"
-        let forbiddenChars = [|'/'; '\\'; '"'; '>'; '<'; '?'; '='; '*'; '|'|]
         let m = 
             args 
             |> List.map splitUnion
@@ -105,7 +143,7 @@ module ArgumentProcessing =
             match fields with 
             | [||] -> 
                 let toolTip = (FSharpValue.MakeUnion (unionCase, [||]) :?> 'T).Usage
-                let value,isFlag = if Map.containsKey unionCase.Name m then Some Flag,true else None,true             
+                let value,isFlag = if Map.containsKey unionCase.Name m then Some Flag,true else None,true
                 unionCase.Name,createAnnotatedArgument value toolTip isMandatory isFlag
             | [|c|] when c.PropertyType.Name = "String" -> 
                 let toolTip = (FSharpValue.MakeUnion (unionCase, [|box ""|]) :?> 'T).Usage
@@ -113,20 +151,11 @@ module ArgumentProcessing =
                     match Map.tryFind unionCase.Name m with
                     | Some value -> 
                         let str = string value.[0]
-                        printfn $"str is {str}"
                         let adjustedStr =
                             if isFileAttribute then
-                                forbiddenChars
-                                |> Array.iter (
-                                    fun fc -> 
-                                        if str.Contains fc then
-                                            log.Error $"Symbol/letter \"{fc}\" is not permitted for identifiers/filenames. Please choose another one."
-                                            raise (Exception "")
-                                )
-                                if str.Contains(' ') then
-                                    log.Warn $"Identifiers/filename \"{str}\" contains one or several space(s). Replaced with underscore(s)."
-                                    str.Replace(" ", "_")
-                                else str
+                                iterForbiddenChars str
+                                checkForReservedFns str
+                                replaceSpace str
                             else str
                         Field adjustedStr
                         |> Some,
@@ -172,8 +201,7 @@ module ArgumentProcessing =
             p.WaitForExit()
 
         /// Deletes the file.
-        let private delete (path:string) = 
-            File.Delete(path) 
+        let private delete (path : string) = File.Delete(path) 
 
         /// Writes a text string to a path.
         let private write (path : string) (text : string) = 
@@ -223,20 +251,34 @@ module ArgumentProcessing =
             |> sprintf "%s\n\n%s" header
     
         /// Splits the string at the first occurence of the char.
+        ///
+        /// Also checks for forbidden characters, reserved file names, and spaces if the key concerns file names.
         let private splitAtFirst (c : char) (s : string) =
+            let checkValue key (valu : string) = 
+                valu.Trim()
+                |> fun trValu ->
+                    if key = "Identifier" then
+                        iterForbiddenChars trValu
+                        checkForReservedFns trValu
+                        replaceSpace trValu
+                    else trValu
             match s.Split c with
             | [|k|]     -> k.Trim(), Flag 
-            | [|k ; v|] -> k.Trim(), v.Trim() |> Field 
-            | a         -> a.[0].Trim(), Array.skip 1 a |> Array.reduce (fun a b ->sprintf "%s%c%s" a c b) |> fun v -> v.Trim() |> Field
+            | [|k ; v|] -> k.Trim(), checkValue k v |> Field
+            | a         -> 
+                let k = a.[0].Trim()
+                k, 
+                Array.skip 1 a 
+                |> Array.reduce (fun a b -> sprintf "%s%c%s" a c b) 
+                |> checkValue k
+                |> Field
 
         /// Deserializes yaml format (key:value) arguments.
         let private deserializeArguments (s:string) =
             s.Split '\n'
             |> Array.choose (fun x -> 
-                if x.StartsWith "#" then
-                    None
-                else 
-                    splitAtFirst ':' x |> Some
+                if x.StartsWith "#" then None
+                else splitAtFirst ':' x |> Some
             )
 
         /// Opens a textprompt containing the result of the serializeF to the user. Returns the deserialized user input.
@@ -307,7 +349,7 @@ module ArgumentProcessing =
             (readF : System.Collections.Generic.IEnumerator<ISADotNet.XLSX.SparseRow> -> 'A)
             (isaItem : 'A) = 
 
-            let log = Logging.createLogger "ArgumentProessingPromptCreateIsaItemQueryLog"
+            let log = Logging.createLogger "ArgumentProcessingPromptCreateIsaItemQueryLog"
 
             let header = 
                 """# For editing the selected item, just provide the desired values for the keys below or change preexisting values
@@ -319,7 +361,7 @@ module ArgumentProcessing =
             let deserializeF (s : string) : 'A =
                 s.Split('\n')
                 |> Seq.choose (fun x ->
-                    x.Replace("\013", "")
+                    x.Replace("\013", "")   // due to Windows CR (carriage return) char
                     |> fun x ->
                         if x.Length = 0 || x.[0] = '#' then None
                         else
@@ -335,7 +377,7 @@ module ArgumentProcessing =
 
         /// Opens a textprompt containing the serialized iniData. Returns the iniData updated with the deserialized user input.
         let createIniDataQuery editorPath (iniData : IniParser.Model.IniData) =
-            let log = Logging.createLogger "ArgumentProessingPromptCreateIniDataQueryLog"
+            let log = Logging.createLogger "ArgumentProcessingPromptCreateIniDataQueryLog"
             let serializeF inp = 
                 IniData.flatten inp
                 |> Seq.map (fun (n,v) -> n + "=" + v)

--- a/src/ArcCommander/CLIArguments/AssayArgs.fs
+++ b/src/ArcCommander/CLIArguments/AssayArgs.fs
@@ -39,17 +39,17 @@ type AssayDeleteArgs =
 
 /// CLI arguments for updating existing assay metadata.
 type AssayUpdateArgs =  
-    | [<AltCommandLine("-s")>][<Unique>][<FileName>]    StudyIdentifier                     of string
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier                     of string
-    | [<Unique>]                                        MeasurementType                     of measurement_type             : string
-    | [<Unique>]                                        MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
-    | [<Unique>]                                        MeasurementTypeTermSourceREF        of measurement_type_term_source : string
-    | [<Unique>]                                        TechnologyType                      of technology_type              : string
-    | [<Unique>]                                        TechnologyTypeTermAccessionNumber   of technology_type_accession    : string
-    | [<Unique>]                                        TechnologyTypeTermSourceREF         of technology_type_term_source  : string
-    | [<Unique>]                                        TechnologyPlatform                  of technology_platform          : string
-    | [<Unique>]                                        ReplaceWithEmptyValues
-    | [<Unique>]                                        AddIfMissing
+    | [<AltCommandLine("-s")>][<Unique>][<FileName>]                StudyIdentifier                     of string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>][<FileName>]   AssayIdentifier                     of string
+    | [<Unique>]                                                    MeasurementType                     of measurement_type             : string
+    | [<Unique>]                                                    MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
+    | [<Unique>]                                                    MeasurementTypeTermSourceREF        of measurement_type_term_source : string
+    | [<Unique>]                                                    TechnologyType                      of technology_type              : string
+    | [<Unique>]                                                    TechnologyTypeTermAccessionNumber   of technology_type_accession    : string
+    | [<Unique>]                                                    TechnologyTypeTermSourceREF         of technology_type_term_source  : string
+    | [<Unique>]                                                    TechnologyPlatform                  of technology_platform          : string
+    | [<Unique>]                                                    ReplaceWithEmptyValues
+    | [<Unique>]                                                    AddIfMissing
     
     interface IArgParserTemplate with
         member this.Usage =
@@ -68,8 +68,8 @@ type AssayUpdateArgs =
 
 /// CLI arguments for interactively editing existing assay metadata.
 type AssayEditArgs = 
-    | [<AltCommandLine("-s")>][<Unique>]                StudyIdentifier of study_identifier : string
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier of assay_identifier : string
+    | [<AltCommandLine("-s")>][<Unique>][<FileNameAttribute>]               StudyIdentifier of study_identifier : string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>][<FileNameAttribute>]  AssayIdentifier of assay_identifier : string
 
     interface IArgParserTemplate with
         member this.Usage =

--- a/src/ArcCommander/CLIArguments/AssayArgs.fs
+++ b/src/ArcCommander/CLIArguments/AssayArgs.fs
@@ -1,17 +1,18 @@
 ﻿namespace ArcCommander.CLIArguments
 
 open Argu 
+open ArcCommander.ArgumentProcessing
 
 /// CLI arguments for empty assay initialization.
 type AssayInitArgs =
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier                     of string
-    | [<Unique>]                                        MeasurementType                     of measurement_type             : string
-    | [<Unique>]                                        MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
-    | [<Unique>]                                        MeasurementTypeTermSourceREF        of measurement_type_term_source : string
-    | [<Unique>]                                        TechnologyType                      of technology_type              : string
-    | [<Unique>]                                        TechnologyTypeTermAccessionNumber   of technology_type_accession    : string
-    | [<Unique>]                                        TechnologyTypeTermSourceREF         of technology_type_term_source  : string
-    | [<Unique>]                                        TechnologyPlatform                  of technology_platform          : string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>][<FileName>]   AssayIdentifier                     of string
+    | [<Unique>]                                                    MeasurementType                     of measurement_type             : string
+    | [<Unique>]                                                    MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
+    | [<Unique>]                                                    MeasurementTypeTermSourceREF        of measurement_type_term_source : string
+    | [<Unique>]                                                    TechnologyType                      of technology_type              : string
+    | [<Unique>]                                                    TechnologyTypeTermAccessionNumber   of technology_type_accession    : string
+    | [<Unique>]                                                    TechnologyTypeTermSourceREF         of technology_type_term_source  : string
+    | [<Unique>]                                                    TechnologyPlatform                  of technology_platform          : string
 
     interface IArgParserTemplate with
         member this.Usage =
@@ -27,7 +28,7 @@ type AssayInitArgs =
 
 /// CLI arguments for deleting assay file structure.
 type AssayDeleteArgs = 
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier                     of string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier of string
     | [<Unique>]                                        Force
 
     interface IArgParserTemplate with
@@ -38,7 +39,7 @@ type AssayDeleteArgs =
 
 /// CLI arguments for updating existing assay metadata.
 type AssayUpdateArgs =  
-    | [<AltCommandLine("-s")>][<Unique>]                StudyIdentifier                     of string
+    | [<AltCommandLine("-s")>][<Unique>][<FileName>]    StudyIdentifier                     of string
     | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier                     of string
     | [<Unique>]                                        MeasurementType                     of measurement_type             : string
     | [<Unique>]                                        MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
@@ -67,8 +68,8 @@ type AssayUpdateArgs =
 
 /// CLI arguments for interactively editing existing assay metadata.
 type AssayEditArgs = 
-    | [<AltCommandLine("-s")>][<Unique>] StudyIdentifier of study_identifier : string
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>] AssayIdentifier of assay_identifier : string
+    | [<AltCommandLine("-s")>][<Unique>]                StudyIdentifier of study_identifier : string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier of assay_identifier : string
 
     interface IArgParserTemplate with
         member this.Usage =
@@ -93,15 +94,15 @@ type AssayUnregisterArgs = AssayEditArgs
 /// CLI arguments for initializing and subsequently registering assay metadata.
 // Same arguments as `register` because all metadata fields that can be updated can also be set while registering a new assay
 type AssayAddArgs =
-    | [<AltCommandLine("-s")>][<Unique>]                StudyIdentifier                     of string
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>]   AssayIdentifier                     of string
-    | [<Unique>]                                        MeasurementType                     of measurement_type             : string
-    | [<Unique>]                                        MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
-    | [<Unique>]                                        MeasurementTypeTermSourceREF        of measurement_type_term_source : string
-    | [<Unique>]                                        TechnologyType                      of technology_type              : string
-    | [<Unique>]                                        TechnologyTypeTermAccessionNumber   of technology_type_accession    : string
-    | [<Unique>]                                        TechnologyTypeTermSourceREF         of technology_type_term_source  : string
-    | [<Unique>]                                        TechnologyPlatform                  of technology_platform          : string
+    | [<AltCommandLine("-s")>][<Unique>][<FileName>]                StudyIdentifier                     of string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>][<FileName>]   AssayIdentifier                     of string
+    | [<Unique>]                                                    MeasurementType                     of measurement_type             : string
+    | [<Unique>]                                                    MeasurementTypeTermAccessionNumber  of measurement_type_accession   : string
+    | [<Unique>]                                                    MeasurementTypeTermSourceREF        of measurement_type_term_source : string
+    | [<Unique>]                                                    TechnologyType                      of technology_type              : string
+    | [<Unique>]                                                    TechnologyTypeTermAccessionNumber   of technology_type_accession    : string
+    | [<Unique>]                                                    TechnologyTypeTermSourceREF         of technology_type_term_source  : string
+    | [<Unique>]                                                    TechnologyPlatform                  of technology_platform          : string
 
     interface IArgParserTemplate with
         member this.Usage =

--- a/src/ArcCommander/CLIArguments/StudyArgs.fs
+++ b/src/ArcCommander/CLIArguments/StudyArgs.fs
@@ -14,13 +14,13 @@ type StudyEditArgs =
 
 /// CLI arguments for updating existing study metadata.
 type StudyUpdateArgs =
-    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>][<FileName>] Identifier of study_identifier : string
-    | [<Unique>] Title of title : string
-    | [<Unique>] Description of description : string
-    | [<Unique>] SubmissionDate of submission_date : string
-    | [<Unique>] PublicReleaseDate of public_release_date : string
-    | [<Unique>] ReplaceWithEmptyValues
-    | [<Unique>] AddIfMissing
+    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>][<FileName>]   Identifier              of study_identifier : string
+    | [<Unique>]                                                    Title                   of title : string
+    | [<Unique>]                                                    Description             of description : string
+    | [<Unique>]                                                    SubmissionDate          of submission_date : string
+    | [<Unique>]                                                    PublicReleaseDate       of public_release_date : string
+    | [<Unique>]                                                    ReplaceWithEmptyValues
+    | [<Unique>]                                                    AddIfMissing
 
     interface IArgParserTemplate with
         member this.Usage =

--- a/src/ArcCommander/CLIArguments/StudyArgs.fs
+++ b/src/ArcCommander/CLIArguments/StudyArgs.fs
@@ -1,6 +1,7 @@
 ﻿namespace ArcCommander.CLIArguments
 
 open Argu 
+open ArcCommander.ArgumentProcessing
 
 /// CLI arguments for interactively editing existing study metadata.
 type StudyEditArgs =
@@ -13,7 +14,7 @@ type StudyEditArgs =
 
 /// CLI arguments for updating existing study metadata.
 type StudyUpdateArgs =
-    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>] Identifier of study_identifier : string
+    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>][<FileName>] Identifier of study_identifier : string
     | [<Unique>] Title of title : string
     | [<Unique>] Description of description : string
     | [<Unique>] SubmissionDate of submission_date : string
@@ -35,7 +36,7 @@ type StudyUpdateArgs =
 
 /// CLI arguments for registering existing study metadata.
 type StudyRegisterArgs = 
-    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>] Identifier of study_identifier : string
+    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>][<FileName>] Identifier of study_identifier : string
     | [<Unique>] Title of title : string
     | [<Unique>] Description of description : string
     | [<Unique>] SubmissionDate of submission_date : string


### PR DESCRIPTION
- file name attribute for Assay- and StudyArgs in CLI arguments
- same for identifiers given via prompt
- all symbols and names not allowed in any of our shipped OSs (Windows, Linux, macOS) are now checked for
- fixes #142 