### PR TITLE
Extended FAKE build script for macOS

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -310,10 +310,13 @@ module PackageTasks =
 
     let publishBinariesMacBoth = BuildTask.createEmpty "PublishBinariesMacBoth" [clean; build; publishBinariesMac; publishBinariesMacARM]
 
-    let packMacBinaries = BuildTask.create "PackMacBinaries" [publishBinariesMacBoth] {
-        let pr = new System.Diagnostics.Process()
-        pr.
-    }
+    // as of now (july 2022), it seems there is now possibility to run lipo on Windows
+    //let packMacBinaries = BuildTask.create "PackMacBinaries" [publishBinariesMacBoth] {
+    //    let pr = new System.Diagnostics.Process()
+    //    pr.StartInfo.FileName <- "lipo"
+    //    pr.StartInfo.Arguments <- "-create -output ArcCommander ./"   // TO DO: add filepaths to both executables (see https://www.kenmuse.com/blog/notarizing-dotnet-console-apps-for-macos/ Chapter "Creating Universal binaries"
+    //    pr.Start() |> ignore
+    //}
 
 module ToolTasks =
 

--- a/build.fsx
+++ b/build.fsx
@@ -283,7 +283,37 @@ module PackageTasks =
         printfn "Beware that assemblyName differs from projectName!"
     }
 
+    let publishBinariesMacARM = BuildTask.create "PublishBinariesMacARM" [clean.IfNeeded; build.IfNeeded] {
+        let outputPath = sprintf "%s/osx-arm64" publishDir
+        solutionFile
+        |> DotNet.publish (fun p ->
+            let standardParams = Fake.DotNet.MSBuild.CliArguments.Create ()
+            {
+                p with
+                    Runtime = Some "osx.12-arm64"
+                    Configuration = DotNet.BuildConfiguration.fromString configuration
+                    OutputPath = Some outputPath
+                    MSBuildParams = {
+                        standardParams with
+                            Properties = [
+                                "Version", stableVersionTag
+                                //"Platform", "arm64"   // throws MSBuild Error although it should work: error MSB4126: The specified solution configuration "Release|ARM64" is invalid. Please specify a valid solution configuration using the Configuration and Platform properties (e.g. MSBuild.exe Solution.sln /p:Configuration=Debug /p:Platform="Any CPU") or leave those properties blank to use the default solution configuration. [C:\Repos\omaus\arcCommander\ArcCommander.sln]
+                                "PublishSingleFile", "true"
+                            ]
+                    }
+            }
+        )
+        printfn "Beware that assemblyName differs from projectName!"
+    }
+
     let publishBinariesAll = BuildTask.createEmpty "PublishBinariesAll" [clean; build; publishBinariesWin; publishBinariesLinux; publishBinariesMac]
+
+    let publishBinariesMacBoth = BuildTask.createEmpty "PublishBinariesMacBoth" [clean; build; publishBinariesMac; publishBinariesMacARM]
+
+    let packMacBinaries = BuildTask.create "PackMacBinaries" [publishBinariesMacBoth] {
+        let pr = new System.Diagnostics.Process()
+        pr.
+    }
 
 module ToolTasks =
 

--- a/publishBinariesMac.cmd
+++ b/publishBinariesMac.cmd
@@ -1,6 +1,5 @@
 @echo off
-dotnet fake build -t publishBinariesMac
-dotnet fake build -t publishBinariesMacARM
+dotnet fake build -t publishBinariesMacBoth
 
 echo DONE!
 timeout 5 >nul

--- a/publishBinariesMac.cmd
+++ b/publishBinariesMac.cmd
@@ -1,4 +1,6 @@
 @echo off
 dotnet fake build -t publishBinariesMac
+dotnet fake build -t publishBinariesMacARM
+
 echo DONE!
 timeout 5 >nul


### PR DESCRIPTION
FAKE build script now has target `publishBinariesMacBoth` which allows for creating executable files for AMD & Intel processor structure (x64/amd64) on the one hand and ARM processor structure (arm64) on the other.

CLI: `dotnet fake build -t publishBinariesMacBoth` to do so