### PR TITLE
Add `--nolfs` flag to `arc get`

### DIFF
--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -34,12 +34,18 @@ module GitAPI =
             | Some branchName -> $" -b {branchName}"
             | None -> ""
 
+        let lfsConfig = 
+            if containsFlag "NoLFS" gitArgs then
+                $" {GitHelper.noLFSConfig}"
+            else
+                ""
+
         if System.IO.Directory.GetFileSystemEntries repoDir |> Array.isEmpty then
             log.Trace("Downloading into current folder.")
-            executeGitCommand repoDir $"clone {remoteAddress}{branch} ." |> ignore
+            executeGitCommand repoDir $"clone {lfsConfig} {remoteAddress}{branch} ." |> ignore
         else 
             log.Trace($"Specified folder \"{repoDir}\" is not empty. Downloading into subfolder.")
-            executeGitCommand repoDir $"clone {remoteAddress}{branch}" |> ignore
+            executeGitCommand repoDir $"clone {lfsConfig} {remoteAddress}{branch}" |> ignore
 
 
     /// Syncs with remote. Commit changes, then pull remote and push to remote.

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -55,9 +55,11 @@ type ArcSyncArgs =
 type ArcGetArgs =
     | [<Mandatory>][<Unique>][<AltCommandLine("-r")>] RepositoryAddress of repository_address:string
     | [<Unique>][<AltCommandLine("-b")>] BranchName         of branch_name:string
+    | [<Unique>][<AltCommandLine("-n")>] NoLFS
 
     interface IArgParserTemplate with
         member this.Usage =
             match this with
-            | RepositoryAddress _   -> "Git remote address from which to pull the ARC"
-            | BranchName _          -> "Branch of the remote address which should be used. If none is given, uses \"main\""
+            | RepositoryAddress _ -> "Git remote address from which to pull the ARC"
+            | BranchName        _ -> "Branch of the remote address which should be used. If none is given, uses \"main\""
+            | NoLFS             _ -> "Does download only the pointers of LFS files, not the file content itself. Ideal for when you're only interested in the experimental metadata, not the data itself."

--- a/src/ArcCommander/GitHelper.fs
+++ b/src/ArcCommander/GitHelper.fs
@@ -10,6 +10,8 @@ module GitHelper =
 
         let log = Logging.createLogger "ExecuteGitCommandLog"
 
+        log.Trace($"Run git {command}")
+
         let procStartInfo = 
             ProcessStartInfo(
                 WorkingDirectory = repoDir,
@@ -104,6 +106,11 @@ module GitHelper =
 
     let clone dir url =
         executeGitCommand dir (sprintf "clone %s" url)
+
+    let noLFSConfig = "-c \"filter.lfs.smudge = git-lfs smudge --skip -- %f\" -c \"filter.lfs.process = git-lfs filter-process --skip\""
+
+    let cloneNoLFS dir url =
+        executeGitCommand dir (sprintf "clone %s %s" noLFSConfig url)        
 
     let cloneWithToken dir token url  =
         let url = formatRepoToken token url


### PR DESCRIPTION
# Add `--nolfs` flag to `arc get`

By using the `--nolfs` (`-n`) flag, arc get will now download only the non lfs file contents when `cloning` an `arc`. This is practival for users who are only interested in the metadata. 

Usage:

```
arc get -r https://git.nfdi4plants.org/brilator/samplearc_rnaseq -n
```

afterwards lfs file content can be updated using 

```
git lfs pull
```


#106