### PR TITLE
Add direct access token storing functionality

### DIFF
--- a/src/ArcCommander/APIs/RemoteAccessAPI.fs
+++ b/src/ArcCommander/APIs/RemoteAccessAPI.fs
@@ -9,16 +9,55 @@ module RemoteAccessAPI =
 
     module AccessToken =
 
+        /// Store a git token using git credential manager.
+        let store (arcConfiguration : ArcConfiguration) (remoteAccessArgs : Map<string,Argument>) =
+
+            let log = Logging.createLogger "GitStoreLog"
+
+            let token = getFieldValueByName "Token" remoteAccessArgs
+
+            let hostAddress = 
+                let ha = 
+                    match tryGetFieldValueByName "Server" remoteAccessArgs with
+                    | Some s -> s
+                    | None -> @"https://git.nfdi4plants.org/"
+                if ha.Contains "https" then ha
+                else $"https://{ha}"
+
+            let user = 
+                match tryGetFieldValueByName "User" remoteAccessArgs with
+                | Some s -> s
+                | None -> @"oauth2"
+
+            log.Info("Start Remote token store")
+        
+            if GitHelper.storeCredentials log hostAddress user token then
+                log.Info($"Token stored successfully")
+
+            else
+                let m = 
+                    [
+                        $"Credentials could not be stored successfully."
+                        $"Check if git is installed and if a credential helper is setup:"
+                        $"Run \"git config --global credential.helper cache\" to cache credentials in memory"
+                        $"or Run \"git config --global credential.helper store\" to save credentials to disk"
+                        $"For more info go to: https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage"
+                    ]
+                    |> List.reduce (fun a b -> a + "\n" + b)
+                log.Error(m)
+
         /// Authenticates to a token service and stores the token using git credential manager.
         let get (arcConfiguration : ArcConfiguration) (remoteAccessArgs : Map<string,Argument>) =
 
             let log = Logging.createLogger "GitAuthenticateLog"
 
             let hostAddress = 
-                let ha = getFieldValueByName "Server" remoteAccessArgs
+                let ha = 
+                    match tryGetFieldValueByName "Server" remoteAccessArgs with
+                    | Some s -> s
+                    | None -> @"https://git.nfdi4plants.org/"
                 if ha.Contains "https" then ha
                 else $"https://{ha}"
-
 
             log.Info("Start Arc Authenticate")
         
@@ -35,29 +74,7 @@ module RemoteAccessAPI =
             match tryReceiveToken log hostAddress arcConfiguration with 
             | Ok token -> 
                 log.Info("Successfully retrieved access token from token service")
-
-                //log.Trace("Try transfer git user metadata to global arcCommander config")
-                //match IniData.tryGetGlobalConfigPath () with
-                //| Some globalConfigPath ->
-                //    IniData.setValueInIniPath globalConfigPath "general.gitname"    (token.FirstName + " " + token.LastName)
-                //    IniData.setValueInIniPath globalConfigPath "general.gitemail"   token.Email
-                //    log.Trace("Successfully transferred git user metadata to global arcCommander config")
-                //| None ->
-                //    log.Error("Could not transfer git user metadata to global arcCommander config")
-
-                if GitHelper.storeCredentials log hostAddress "oauth2" token.AccessToken then
-                    log.Info($"Finished Authentication")
-
-                else
-                    let m = 
-                        [
-                            $"Authentication worked, but credentials could not be stored successfully."
-                            $"Check if git is installed and if a credential helper is setup:"
-                            $"Run \"git config --global credential.helper cache\" to cache credentials in memory"
-                            $"or Run \"git config --global credential.helper store\" to save credentials to disk"
-                            $"For more info go to: https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage"
-                        ]
-                        |> List.reduce (fun a b -> a + "\n" + b)
-                    log.Error(m)
+                store arcConfiguration (Map.add "Token" (Field token.AccessToken) remoteAccessArgs)
             | Error err -> 
                 log.Error($"Could not retrieve access token: {err.Message}")
+

--- a/src/ArcCommander/CLIArguments/RemoteAccessArgs.fs
+++ b/src/ArcCommander/CLIArguments/RemoteAccessArgs.fs
@@ -7,13 +7,26 @@ module AccessToken =
 
     /// CLI arguments for receiving access tokens
     type AccessTokenGetArgs =  
-        | [<Mandatory>][<AltCommandLine("-s")>][<Unique>] Server of string
+        | [<AltCommandLine("-s")>][<Unique>] Server of string
         | [<Unique>] OAuth2
         | [<Unique>] OpenID
 
         interface IArgParserTemplate with
             member this.Usage =
                 match this with
-                | Server    _ -> "URL of the service for which you want to receive an access token."
+                | Server    _ -> "URL of the service for which you want to receive an access token. If no url is given, \"git.nfdi4plants.org\" is used as default."
                 | OAuth2    _ -> "Use OAuth2 authorization protocol. E.g. used by GitHub."
                 | OpenID    _ -> "Use OpenID connect authorization protocol. E.g. used by DataPlant GitLab instances."
+
+    /// CLI arguments for receiving access tokens
+    type AccessTokenStoreArgs = 
+        | [<Mandatory>][<AltCommandLine("-t")>][<Unique>] Token of string
+        | [<AltCommandLine("-u")>][<Unique>] User of string
+        | [<AltCommandLine("-s")>][<Unique>] Server of string
+
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | Token     _ -> "The access token you want to store."
+                | User      _ -> "User name for which the token applies. If no name is given, \"oauth2\" is used as a default value. This is also the value expected by the \"git.nfdi4plants.org\" GitLab instance."
+                | Server    _ -> "URL of the service for which you want to receive an access token. If no url is given, \"git.nfdi4plants.org\" is used as default."

--- a/src/ArcCommander/Commands/RemoteAccessCommand.fs
+++ b/src/ArcCommander/Commands/RemoteAccessCommand.fs
@@ -19,10 +19,12 @@ type RemoteAccessCommand =
 
 and AccessTokenCommand =
 
+    | [<CliPrefix(CliPrefix.None)>] Store   of store_args:   ParseResults<AccessTokenStoreArgs>
     | [<CliPrefix(CliPrefix.None)>] Get     of get_args:     ParseResults<AccessTokenGetArgs>
 
     interface IArgParserTemplate with
         member this.Usage =
             match this with
+            | Store _ -> "Store a git access token using the credential manager."
             | Get   _ -> "Receive and store a git access token by authenticating to a token delivery service."
 

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -71,7 +71,8 @@ let processCommandWithoutArgs (arcConfiguration : ArcConfiguration) commandF =
 
 let handleRemoteAccessAccessTokenSubCommands arcConfiguration accessTokenVerb =
     match accessTokenVerb with
-    | AccessTokenCommand.Get r  -> processCommand arcConfiguration RemoteAccessAPI.AccessToken.get r
+    | AccessTokenCommand.Store r    -> processCommand arcConfiguration RemoteAccessAPI.AccessToken.store r
+    | AccessTokenCommand.Get r      -> processCommand arcConfiguration RemoteAccessAPI.AccessToken.get r
 
 let handleStudyContactsSubCommands arcConfiguration contactsVerb =
     match contactsVerb with


### PR DESCRIPTION
- Add a command for manually storing an git access token.
Usage:
![image](https://user-images.githubusercontent.com/17880410/204033399-628bfb0d-6b39-42e6-a537-1c185b0710bb.png)
Example: `arc remote token store -t "MyToken"`


- Additionally, made the `-s` flag in the token get command optional. Now it will authenticate against `https://git.nfdi4plants.org/` by default if no other host is specified
