### PR TITLE
Automatically update version of ArcCommander release in Readme.md

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -428,6 +428,14 @@ module ReleaseNoteTasks =
         s.Replace(lastVersion,$"v{stableVersionTag}")
         |> File.writeString false filePath
 
+    let updateVersionOfReadme (stableVersionTag) = 
+        printfn "Start updating readme to version %s" stableVersionTag
+        let filePath = Path.Combine(__SOURCE_DIRECTORY__,"README.md")
+        let s = File.readAsString filePath
+        let lastVersion = System.Text.RegularExpressions.Regex.Match(s,@"v\d+.\d+.\d+").Value
+        s.Replace(lastVersion,$"v{stableVersionTag}")
+        |> File.writeString false filePath
+
     let createAssemblyVersion = BuildTask.create "createvfs" [] {
         AssemblyVersion.create ProjectInfo.gitName
     }
@@ -444,6 +452,7 @@ module ReleaseNoteTasks =
         let stableVersionTag = (sprintf "%i.%i.%i" stableVersion.Major stableVersion.Minor stableVersion.Patch )
 
         updateVersionOfReleaseWorkflow (stableVersionTag)
+        updateVersionOfReadme (stableVersionTag)
     )
 
     let githubDraft = BuildTask.createFn "GithubDraft" [] (fun config ->


### PR DESCRIPTION
ArcCommander is now automatically updated in the Readme.md when running the "ReleaseNotes" build target.

closes #116