### PR TITLE
Throw warning when character length of file name arguments exceed 31

### DIFF
--- a/src/ArcCommander/ArgumentProcessing.fs
+++ b/src/ArcCommander/ArgumentProcessing.fs
@@ -77,6 +77,12 @@ module ArgumentProcessing =
             log.Error $"Identifier/filename \"{str}\" is a reserved filename. Please choose another one."
             raise (Exception "")
 
+    /// Takes a string and checks if it is longer than 31 chars
+    let private checkForNameLength (str : string) =
+        let log = Logging.createLogger "ArgumentProcessingCheckForFileNameLength"
+        if seq str |> Seq.length |> (<) 31 then
+            log.Warn $"Identifier/filename \"{str}\" is longer than 31 characters, which might cause problems in excel sheets."
+        
     /// Returns true if the argument flag of name k was given by the user.
     let containsFlag k (arguments : Map<string,Argument>) =
         let log = Logging.createLogger "ArgumentProcessingContainsFlagLog"
@@ -155,6 +161,7 @@ module ArgumentProcessing =
                             if isFileAttribute then
                                 iterForbiddenChars str
                                 checkForReservedFns str
+                                checkForNameLength str
                                 replaceSpace str
                             else str
                         Field adjustedStr
@@ -260,6 +267,7 @@ module ArgumentProcessing =
                     if key.Contains "Identifier" then
                         iterForbiddenChars trValu
                         checkForReservedFns trValu
+                        checkForNameLength trValu
                         replaceSpace trValu
                     else trValu
             match s.Split c with

--- a/src/ArcCommander/CLIArguments/AssayArgs.fs
+++ b/src/ArcCommander/CLIArguments/AssayArgs.fs
@@ -68,8 +68,8 @@ type AssayUpdateArgs =
 
 /// CLI arguments for interactively editing existing assay metadata.
 type AssayEditArgs = 
-    | [<AltCommandLine("-s")>][<Unique>][<FileNameAttribute>]               StudyIdentifier of study_identifier : string
-    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>][<FileNameAttribute>]  AssayIdentifier of assay_identifier : string
+    | [<AltCommandLine("-s")>][<Unique>][<FileName>]               StudyIdentifier of study_identifier : string
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>][<FileName>]  AssayIdentifier of assay_identifier : string
 
     interface IArgParserTemplate with
         member this.Usage =

--- a/src/ArcCommander/CLIArguments/InvestigationArgs.fs
+++ b/src/ArcCommander/CLIArguments/InvestigationArgs.fs
@@ -1,13 +1,14 @@
 ﻿namespace ArcCommander.CLIArguments
 
 open Argu 
+open ArcCommander.ArgumentProcessing
 
 /// CLI arguments for creating a new investigation file for the arc
 // in the case of investigations 'empty' does not mean empty file but rather an 
 // investigation without studies/assays. To reflect the need for metadata here,
 // this command is called `create` instead of `init`
 type InvestigationCreateArgs = 
-    | [<Mandatory>][<AltCommandLine("-i")>][<Unique>] Identifier of investigation_identifier:string
+    | [<Mandatory>][<AltCommandLine("-i")>][<Unique>][<FileName>] Identifier of investigation_identifier:string
     | [<Unique>] Title of title:string
     | [<Unique>] Description of description:string
     | [<Unique>] SubmissionDate of submission_date:string
@@ -24,7 +25,7 @@ type InvestigationCreateArgs =
 
 /// CLI arguments updating the arc's existing investigation file
 type InvestigationUpdateArgs = 
-    | [<Mandatory>][<AltCommandLine("-i")>][<Unique>] Identifier of investigation_identifier:string
+    | [<Mandatory>][<AltCommandLine("-i")>][<Unique>][<FileName>] Identifier of investigation_identifier:string
     | [<Unique>] Title of title:string
     | [<Unique>] Description of description:string
     | [<Unique>] SubmissionDate of submission_date:string


### PR DESCRIPTION
Now a `warning` is thrown when a string with a length of `more than 31 characters` is used as an input value for `filename` or `identifier` arguments

![image](https://user-images.githubusercontent.com/17880410/208726585-5f392c72-f718-4382-9b78-fc056983144c.png)


closes #126