### PR TITLE
Add `arc server` functionality

### DIFF
--- a/ArcCommander.sln
+++ b/ArcCommander.sln
@@ -11,10 +11,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "meta", "meta", "{655069DF-7
 	ProjectSection(SolutionItems) = preProject
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
 		build.cmd = build.cmd
 		build.sh = build.sh
 		global.json = global.json
 		README.md = README.md
+		.github\workflows\release-github.yml = .github\workflows\release-github.yml
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
 EndProject
@@ -25,12 +27,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".devcontainer", ".devcontai
 	EndProjectSection
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Build", "build\Build.fsproj", "{44736484-8325-4C62-8BA5-3091FB02FAE7}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{B2A16494-7397-4494-9954-44C4E18F16AD}"
-	ProjectSection(SolutionItems) = preProject
-		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
-		.github\workflows\release-github.yml = .github\workflows\release-github.yml
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -18,8 +18,8 @@
     <FsDocsLicenseLink>https://github.com/nfdi4plants/arcCommander/blob/developer/LICENSE</FsDocsLicenseLink>
     <FsDocsReleaseNotesLink>https://github.com/nfdi4plants/arcCommander/blob/developer/RELEASE_NOTES.md</FsDocsReleaseNotesLink>
     <AssemblyName>arc</AssemblyName>
-  </PropertyGroup>   
-  
+  </PropertyGroup>
+
   <!--Compile-States-->
   <ItemGroup>
     <None Include="config_unix\config" CopyToOutputDirectory="PreserveNewest" />
@@ -56,12 +56,20 @@
     <Compile Include="APIs\ExternalExecutables.fs" />
     <Compile Include="Server\Version.fs" />
     <Compile Include="Program.fs" />
-	  
+
   </ItemGroup>
-  
+
+  <!--This copies our static files for the server function to the location of the dll. Allowing us to access it.-->
+  <ItemGroup>
+    <Content Include="Server\WebRoot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <!--References-->
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="6.0.3-beta.22076.4" />
+    <PackageReference Include="arcIO.NET" Version="0.0.4" />
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Fake.IO.FileSystem" Version="5.20.4" />
     <PackageReference Include="Fake.Tools.Git" Version="5.20.4" />
@@ -72,6 +80,7 @@
     <PackageReference Include="ISADotNet.XLSX" Version="0.4.0-preview.5" />
     <PackageReference Include="JWT" Version="8.9.0" />
     <PackageReference Include="Microsoft.Net.Http.Server" Version="1.1.4" />
+    <PackageReference Include="Giraffe" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.7.13" />
   </ItemGroup>
 </Project>

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -56,16 +56,18 @@
     <Compile Include="APIs\ExternalExecutables.fs" />
     <Compile Include="Server\Version.fs" />
     <Compile Include="Server\ArcAPIHandler.fs" />
+    <Compile Include="Server\ApiDocs\BaseView.Docs.fs" />
+    <Compile Include="Server\ApiDocs\ArcApi.Docs.fs" />
+    <!--This copies our static files for the server function to the location of the dll. Allowing us to access it.-->
+    <Content Include="Server\WebRoot\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Compile Include="Server.fs" />
     <Compile Include="Program.fs" />
 
   </ItemGroup>
 
-  <!--This copies our static files for the server function to the location of the dll. Allowing us to access it.-->
-  <ItemGroup>
-    <Content Include="Server\WebRoot\**\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+  <ItemGroup />
 
   <!--References-->
   <ItemGroup>

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -55,6 +55,7 @@
     <Compile Include="APIs\ArcAPI.fs" />
     <Compile Include="APIs\ExternalExecutables.fs" />
     <Compile Include="Server\Version.fs" />
+    <Compile Include="Server\ArcAPIHandler.fs" />
     <Compile Include="Program.fs" />
 
   </ItemGroup>

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -18,7 +18,7 @@ type ArcInitArgs =
             match this with
             | Owner               _ ->  "Owner of the ARC"
             | Branch              _ ->  "Name of the git branch to be created"
-            | RepositoryAddress   _ ->  "Github address"
+            | RepositoryAddress   _ ->  "Git repository address"
             | EditorPath          _ ->  "The path leading to the editor used for text prompts (Default in Windows is Notepad; Default in Unix systems is Nano)"
             | GitLFSByteThreshold _ ->  "The git LFS file size threshold in bytes. File larger than this threshold will be tracked by git LFS (Default Value is 150000000 Bytes ~ 150 MB)."
             | Gitignore           _ ->  "Use this flag if you want a default .gitignore to be added to the initialized repo"
@@ -63,3 +63,12 @@ type ArcGetArgs =
             | RepositoryAddress _ -> "Git remote address from which to pull the ARC"
             | BranchName        _ -> "Branch of the remote address which should be used. If none is given, uses \"main\""
             | NoLFS             _ -> "Does download only the pointers of LFS files, not the file content itself. Ideal for when you're only interested in the experimental metadata, not the data itself."
+
+
+type ArcServerArgs =
+    | [<Unique>][<AltCommandLine("-p")>] Port           of port_address : string
+
+    interface IArgParserTemplate with
+        member this.Usage =
+            match this with
+            | Port              _ -> "<insert description here>"

--- a/src/ArcCommander/Commands/ArcCommand.fs
+++ b/src/ArcCommander/Commands/ArcCommand.fs
@@ -13,6 +13,7 @@ type ArcCommand =
     | [<CliPrefix(CliPrefix.None)>]                             Export          of export_args  : ParseResults<ArcExportArgs>
     | [<CliPrefix(CliPrefix.None)>]                             Sync            of sync_args    : ParseResults<ArcSyncArgs>
     | [<CliPrefix(CliPrefix.None)>]                             Get             of get_args     : ParseResults<ArcGetArgs>
+    | [<CliPrefix(CliPrefix.None)>]                             Server          of server_args  : ParseResults<ArcServerArgs>
     | [<CliPrefix(CliPrefix.None)>][<SubCommand()>]             Update
     | [<CliPrefix(CliPrefix.DoubleDash)>][<SubCommand()>]       Version
     ///Subcommands
@@ -38,3 +39,4 @@ type ArcCommand =
             | Assay         _   -> "Assay functions"
             | Configuration _   -> "Configuration editing"
             | Version       _   -> "Get the ArcCommander's current version"
+            | Server        _   -> "Start the ArcCommander as a local server"

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -214,6 +214,7 @@ let handleCommand arcConfiguration command =
     // Verbs
     | Init r                    -> processCommand                   arcConfiguration ArcAPI.init r
     | Export r                  -> processCommand                   arcConfiguration ArcAPI.export r
+    | Server r                  -> processCommand                   arcConfiguration Server.start r
     | Update                    -> processCommandWithoutArgs        arcConfiguration ArcAPI.update
     | Version                   -> processCommandWithoutArgs        arcConfiguration ArcAPI.version
     // Git Verbs

--- a/src/ArcCommander/Server.fs
+++ b/src/ArcCommander/Server.fs
@@ -1,0 +1,109 @@
+﻿namespace ArcCommander
+
+open System.IO
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.DependencyInjection
+open Giraffe
+open ArcCommander.ArgumentProcessing
+open Microsoft.AspNetCore.Http
+open Microsoft.AspNetCore.Cors.Infrastructure
+open Microsoft.AspNetCore.StaticFiles
+
+module Server =
+
+    /// Test-API function
+    let numberHandler : HttpHandler =
+        let funFunction myInt = $"Your number is {myInt}!"
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            task {
+                let! number = ctx.BindJsonAsync<int>()
+                let nextNumber = funFunction number
+                // das machen wir so!
+                return! json {| ``is this your number?`` = nextNumber |} next ctx
+            }
+
+    /// API function for checking the application's version.
+    let versionHandler : HttpHandler =
+        fun (next : HttpFunc) (ctx : HttpContext) ->
+            task {
+                let ver = System.AssemblyVersionInformation.AssemblyVersion
+                return! json ver next ctx
+            }
+
+    /// Endpoints
+    let webApp =
+        // TO DO: establish versioning for APIs: e.g. `localhost/api/v1/ping`, "v1" should be the ArcCommander's version
+        choose [
+            GET >=> choose [
+                route "/version" >=> versionHandler
+                route "/ping" >=> text "pong"
+            ]
+            POST >=> choose [
+                route "/ping" >=> numberHandler
+            ]
+            subRoute "/v1" (
+                subRoute "/arc" (
+                    choose [
+                        GET >=> route "/docs" >=> htmlView ArcApi.Docs.view
+                        POST >=> choose [
+                            route "/get" >=> ArcAPIHandler.isaJsonToARCHandler
+                            route "/init" >=> ArcAPIHandler.arcInitHandler
+                            route "/import" >=> ArcAPIHandler.arcImportHandler
+                        ]
+                    ]
+                )
+            )
+        ]
+
+    let corsPolicyName = "_myAllowSpecificOrigins"
+
+    let corsPolicyConfig =
+        fun (b : CorsPolicyBuilder) ->
+            b
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowAnyOrigin()
+            |> ignore
+
+    let configureApp (app : IApplicationBuilder) =
+        let provider = new FileExtensionContentTypeProvider()
+        provider.Mappings.Add(".yaml", "application/x-yaml")
+        app.UseStaticFiles(
+            let opt = new StaticFileOptions()
+            opt.ContentTypeProvider <- provider
+            opt
+        ) |> ignore
+        // Add Giraffe to the ASP.NET Core pipeline
+        app.UseCors(corsPolicyName) |> ignore
+        app.UseGiraffe webApp
+
+    let configureServices (services : IServiceCollection) =
+        // Add Giraffe dependencies
+        services.AddCors(fun options -> options.AddPolicy(corsPolicyName, corsPolicyConfig)) |> ignore
+        services.AddGiraffe() |> ignore
+
+    let start arcConfiguration (arcServerArgs : Map<string,Argument>) =
+
+        let port = 
+            tryGetFieldValueByName "Port" arcServerArgs
+            |> Option.defaultValue "5000"
+
+        // https://trustbit.tech/blog/2021/03/12/introduction-to-web-programming-in-f-sharp-with-giraffe-part-3
+        // This only works because we added webroot folder to be included in .fsproj
+        /// returns folder of dll in bin/.. somethingsomething
+        let contentRoot = Directory.GetCurrentDirectory()
+        let webRoot = Path.Combine(contentRoot, "Server/WebRoot")
+
+        Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(
+                fun webHostBuilder ->
+                    webHostBuilder
+                        .UseWebRoot(webRoot)
+                        .UseUrls([|$"http://*:{port}"|])
+                        .Configure(configureApp)
+                        .ConfigureServices(configureServices)
+                        |> ignore)
+            .Build()
+            .Run()

--- a/src/ArcCommander/Server/ApiDocs/ArcApi.Docs.fs
+++ b/src/ArcCommander/Server/ApiDocs/ArcApi.Docs.fs
@@ -1,0 +1,3 @@
+﻿module ArcApi.Docs
+
+let view = Docs.baseViews "IArcAPI_v1.yaml"

--- a/src/ArcCommander/Server/ApiDocs/BaseView.Docs.fs
+++ b/src/ArcCommander/Server/ApiDocs/BaseView.Docs.fs
@@ -1,0 +1,39 @@
+﻿module Docs
+
+open Giraffe.ViewEngine
+
+let private head = 
+    head [] [
+        meta [_charset "utf-8"]
+        meta [_name "viewport"; _content "width=device-width, initial-scale=1"]
+        meta [_name "description"; _content "SwaggerUI"]
+        title [] [str "SwaggerUI"]
+        link [_rel "shortcut icon"; _type "image/png"; _href "https://raw.githubusercontent.com/nfdi4plants/Branding/master/icons/DataPLANT/favicons/favicon_bg_transparent.png" ]
+        link [_rel "stylesheet"; _href "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css"]
+    ]
+
+let private js_binder (yamlFileName:string) = 
+    sprintf """
+        const url = new URL('./%s', window.location.origin)
+        window.onload = () => {
+            window.ui = SwaggerUIBundle({
+                url: url.href,
+                dom_id: '#swagger-ui',
+            });
+        };
+    """ yamlFileName
+
+let private body (yamlFileName:string) =
+    body [] [
+        div [_id "swagger-ui"] []
+        script [_src "https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js"; _crossorigin ""] []
+        script [] [
+            rawText (js_binder yamlFileName)
+        ]
+    ]
+
+let baseViews (yamlFileName:string) =
+    html [] [
+        head
+        body yamlFileName
+    ]

--- a/src/ArcCommander/Server/ArcAPIHandler.fs
+++ b/src/ArcCommander/Server/ArcAPIHandler.fs
@@ -1,0 +1,78 @@
+﻿module ArcAPIHandler
+
+open Giraffe
+open Microsoft.AspNetCore.Http
+open System
+open System.IO
+open System.IO.Compression
+open ArcCommander
+open ArcCommander.APIs
+open ISADotNet
+
+/// 
+let isaJsonToARCHandler : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        // modified from: https://stackoverflow.com/questions/17232414/creating-a-zip-archive-in-memory-using-system-io-compression
+        task {
+            let isaJson = ctx.Request.Body
+            let ms = new MemoryStream()
+            let! _ = isaJson.CopyToAsync(ms)
+            let isaJsonBA = ms.ToArray()
+
+            let getByteArray (fileName : string) (data : byte []) =
+                try
+                    use ms = new MemoryStream()
+                    (
+                        use archive = new ZipArchive(ms, ZipArchiveMode.Create)
+                        let entry = archive.CreateEntry(fileName)
+                        use entryStream = entry.Open()
+                        use bw = new BinaryWriter(entryStream)
+                        bw.Write(data)
+                    )
+                    (ms.ToArray())
+                with e -> failwithf "Cannot zip stream %s: %s" fileName e.Message
+            let res = getByteArray "arc.json" isaJsonBA
+            return! ctx.WriteBytesAsync res
+        }
+
+//type InitConfig = {
+//    path    : string
+//}
+
+let arcInitHandler : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        task {
+            let! config = ctx.BindJsonAsync<{|path : string|}>()
+            //let arcConfig = IniData.createDefault
+            //ArcAPI.init
+
+            return! json config next ctx
+        }
+
+//type AlibiJson = {
+//    Alles : string
+//}
+
+/// Gets an ISA-JSON string via POST request and returns a byte array of a zipped archive of an ARC created from it.
+let arcImportHandler : HttpHandler =
+    fun (next : HttpFunc) (ctx : HttpContext) ->
+        task {
+            let! isaJsonString = ctx.BindJsonAsync<string>()
+
+            let tmpDir = Path.Combine(Path.GetTempPath(), "tmpArc")
+            let tmpZip = Path.Combine(Path.GetTempPath(), "tmpArc.zip")
+
+            ISADotNet.Json.Investigation.fromString isaJsonString
+            |> fun i -> {i with Remarks = []}
+            |> arcIO.NET.Arc.importFromInvestigation tmpDir
+
+            System.IO.Compression.ZipFile.CreateFromDirectory(tmpDir,tmpZip )
+
+            Directory.Delete(tmpDir, true)
+
+            let byteArc : byte [] = File.ReadAllBytes tmpZip
+
+            File.Delete tmpZip
+
+            return! ctx.WriteBytesAsync byteArc
+        }

--- a/src/ArcCommander/Server/WebRoot/IArcAPI_v1.yaml
+++ b/src/ArcCommander/Server/WebRoot/IArcAPI_v1.yaml
@@ -1,0 +1,80 @@
+﻿openapi: 3.0.3
+info:
+  version: 0.0.1
+  title: ARC API v1
+  description: |-
+    ARC API docs description
+    email: info@nfdi4plants.org
+servers:
+  - url: "http://localhost:5000"
+    description: "Local Test"
+paths:
+  /ping:
+    get:
+      summary: "Test function to verify client server connection."
+      description: "This function is only used for testing connection. If client has connection to server this request will return `pong`."
+      operationId: GET_ping
+      responses:
+        200:
+          description: "OK"
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                Only_Result: 
+                  summary: This api must always return "pong".
+                  value: "pong"
+    post:
+      summary: "Test function to verify client server connection."
+      description: "This function is only used for testing connection. If client has connection to server and requests an integer, this request will return it."
+      operationId: POST_ping
+      requestBody:
+        description: "Test POST API request."
+        content:
+          application/json:
+            schema:
+              type: integer
+            examples:
+              the_answer:
+                summary: any number
+                value: 42
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  "is this your number?": 
+                    type: string
+              examples:
+                the_answer: 
+                  value:
+                    "is this your number?": "Your number is 42!"
+
+  /v1/arc/get:
+    post:
+      summary: "Takes an ISA-JSON as byte stream and returns a byte stream, consisting of the corresponding ARC created from it as a ZIP archive."
+      description: |
+        Give an ISA-JSON as byte stream via Http Request.
+        The ArcCommander server as backend will process and create the resulting ARC out of it. The ARC gets compressed as a ZIP archive.
+        This ZIP archive is then returned as a byte stream again.
+      operationId: POST_v1/arc/get
+      requestBody:
+        description: |
+          A JSON file, consisting of ISA, in the form of a byte stream.
+        content:
+          "*/*":
+            schema:
+              type: string
+              format: byte
+      responses:
+        200:
+          description: "OK"
+          content:
+            "*/*":
+              schema:
+                type: string
+                format: byte


### PR DESCRIPTION
- New `arc server` functionality which allows the ArcCommander to operate as a local server
- Commands and arguments added to Argu tree respectively
- Current functionality according to API docs:
  - Connection test (`/ping` as GET and POST)
  - Transformation of an ISA JSON byte stream into an ARC (`/v1/arc/get` as POST)