### PR TITLE
Tests and fixes

### DIFF
--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -65,7 +65,7 @@ module ArcAPI =
 
         let editor              = arcArgs.TryGetFieldValue ArcInitArgs.EditorPath
         let gitLFSThreshold     = arcArgs.TryGetFieldValue ArcInitArgs.GitLFSByteThreshold 
-        let branch              = arcArgs.TryGetFieldValue ArcInitArgs.Branch
+        let branch              = arcArgs.TryGetFieldValue ArcInitArgs.Branch |> Option.defaultValue GitHelper.defaultBranch
         let repositoryAddress   = arcArgs.TryGetFieldValue ArcInitArgs.RepositoryAddress 
         let identifier =    
             arcArgs.TryGetFieldValue ArcInitArgs.Identifier
@@ -79,6 +79,14 @@ module ArcAPI =
 
         let isa = ArcInvestigation.create(identifier)
         ARC(isa).Write(workDir,true)     
+
+        GeneralConfiguration.tryGetRootfolder arcConfiguration
+        |> Option.iter (fun p -> 
+            let dir = Path.Combine(workDir,p)
+            Directory.CreateDirectory dir |> ignore
+            let p = Path.Combine(dir,".gitkeep")
+            File.WriteAllText(p,"")
+        )       
 
         log.Trace("Set configuration")
 

--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -87,9 +87,9 @@ module GitAPI =
 
             let allFilesPlusSizes = allFiles |> List.map( fun x -> x, System.IO.FileInfo(x).Length )
 
-            let trackWithAdd (file : string) =
+            //let trackWithAdd (file : string) =
 
-                executeGitCommand repoDir $"add \"{file}\"" |> ignore
+            //    executeGitCommand repoDir $"add \"{file}\"" |> ignore
 
             let trackWithLFS (file : string) =
 
@@ -98,7 +98,7 @@ module GitAPI =
                 if GitHelper.containsLFSRule ruleSet lfsPath |> not then
                     executeGitCommand repoDir $"lfs track \"{lfsPath}\"" |> ignore
 
-                trackWithAdd file
+                //trackWithAdd file
 
         
             let gitLfsRules = GeneralConfiguration.getGitLfsRules arcConfiguration
@@ -119,17 +119,18 @@ module GitAPI =
                     // Track files larger than the git lfs threshold with git lfs. If no threshold is set, track no files with git lfs
                     match gitLfsThreshold with
                     | Some thr when size > thr -> trackWithLFS file
-                    | _ -> trackWithAdd file
+                    | _ -> () //trackWithAdd file
             )
 
+            //executeGitCommand repoDir $"add \"{file}\""
 
-            executeGitCommand repoDir ("add -u") |> ignore
+            executeGitCommand repoDir ("add .") |> ignore
             printfn "-----------------------------"
 
             // commit all changes
             let commitMessage =
                 match arcArgs.TryGetFieldValue ArcSyncArgs.CommitMessage with
-                | None -> "Update"
+                | None -> "sync changes via ARCCommander"
                 | Some s -> s
 
             // print git status if verbose
@@ -140,7 +141,7 @@ module GitAPI =
 
             Fake.Tools.Git.Commit.exec repoDir commitMessage |> ignore
         
-            let branch = arcArgs.TryGetFieldValue ArcSyncArgs.Branch |> Option.defaultValue "main"
+            let branch = arcArgs.TryGetFieldValue ArcSyncArgs.Branch |> Option.defaultValue GitHelper.defaultBranch
 
             executeGitCommand repoDir $"branch -M {branch}" |> ignore
 

--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -141,7 +141,12 @@ module GitAPI =
 
             Fake.Tools.Git.Commit.exec repoDir commitMessage |> ignore
         
-            let branch = arcArgs.TryGetFieldValue ArcSyncArgs.Branch |> Option.defaultValue GitHelper.defaultBranch
+            let branch = 
+                match arcArgs.TryGetFieldValue ArcSyncArgs.Branch with
+                | Some b -> b
+                | None -> 
+                    GitHelper.tryGetBranch repoDir
+                    |> Option.defaultValue GitHelper.defaultBranch
 
             executeGitCommand repoDir $"branch -M {branch}" |> ignore
 

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -71,7 +71,7 @@
   <!--References-->
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="7.0.400" />
-    <PackageReference Include="ARCtrl.NET" Version="1.0.0-alpha3" />
+    <PackageReference Include="ARCtrl.NET" Version="1.0.0-alpha4" />
     <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
     <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />

--- a/src/ArcCommander/ArcConfiguration.fs
+++ b/src/ArcCommander/ArcConfiguration.fs
@@ -136,9 +136,17 @@ module GeneralConfiguration =
     let tryGetEditor configuration = 
         Map.tryFind "editor" configuration.General
 
-     /// Returns the path to the text editor used for querying user input.
+    /// Returns the path to the text editor used for querying user input.
     let getEditor configuration = 
         Map.find "editor" configuration.General
+
+    /// Returns the path to the text editor used for querying user input.
+    let tryGetRootfolder configuration = 
+        Map.tryFind "rootfolder" configuration.General
+
+    /// Returns the path to the text editor used for querying user input.
+    let getRootfolder configuration = 
+        Map.find "rootfolder" configuration.General
 
     /// Returns the path to the ARC if it exists. Else returns None.
     let tryGetWorkDirectory configuration = 

--- a/src/ArcCommander/Commands/ConfigurationCommand.fs
+++ b/src/ArcCommander/Commands/ConfigurationCommand.fs
@@ -17,7 +17,7 @@ type ConfigurationCommand =
         member this.Usage =
             match this with
             | Edit       _ -> "Open and edit an existing assay in the ARC with a text editor. Arguments passed for this command will be pre-set in the editor."
-            | List       _ -> "List all assays registered in the ARC"
-            | Set        _ -> "Assign the given value to the given name"
-            | Unset      _ -> "Remove the value bound to the given name" 
-            | SetGitUser _ -> "Transfer the git user metadata from the global arc config to the git config. These are used for commits. Alternative e-mail and username can be specified"
+            | List       _ -> "List all ARC settings."
+            | Set        _ -> "Assign the given value to the given name."
+            | Unset      _ -> "Remove the value bound to the given name." 
+            | SetGitUser _ -> "Transfer the git user metadata from the global arc config to the git config. These are used for commits. Alternative e-mail and username can be specified."

--- a/src/ArcCommander/GitHelper.fs
+++ b/src/ArcCommander/GitHelper.fs
@@ -71,6 +71,11 @@ module GitHelper =
     //let formatRepoToken (token : Authentication.IdentityToken) (url : string) = 
     //    formatRepoString token.UserName token.GitAccessToken url
 
+    let tryGetBranch (dir : string) =
+        let r = executeGitCommandWithResponse dir "branch --show-current"
+        if r.Count = 0 then None
+        else Some r.[0]
+
     let setLocalEmail (dir : string) (email : string) =
         executeGitCommand dir (sprintf "config user.email \"%s\"" email)
 

--- a/src/ArcCommander/GitHelper.fs
+++ b/src/ArcCommander/GitHelper.fs
@@ -7,6 +7,9 @@ open ARCtrl.NET
 
 module GitHelper =
 
+    [<Literal>]
+    let defaultBranch = "main"
+
     /// Executes Git command and returns git output.
     let executeGitCommandWithResponse (repoDir : string) (command : string) =
 

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -194,7 +194,7 @@ module IniData =
             |> Option.bind (tryGetValue key)
         with 
         | err -> 
-            log.Error($"Could not retrieve value with given name.\n {err.ToString()}")
+            log.Info($"Could not retrieve value with given name.\n {err.ToString()}")
             None
 
     /// Returns true if the name (section+key) is set in the iniData.
@@ -216,7 +216,7 @@ module IniData =
             iniData.[section].[key] <- value
             Some iniData
         else
-            log.Error($"Name {name} does not exist in the config.")
+            log.Info($"Name {name} does not exist in the config.")
             None
 
     /// If the name is already set in the config, assigns a new value to it.
@@ -237,7 +237,7 @@ module IniData =
             iniData.[section].RemoveKey key |> ignore
             Some iniData
         else
-            log.Error($"Name {name} does not exist in the config.")
+            log.Info($"Name {name} does not exist in the config.")
             None
 
     /// If the name is set in the config, removes it.
@@ -254,7 +254,7 @@ module IniData =
     let tryAddValue (name : string) (value : string) (iniData : IniData) =
         let log = Logging.createLogger "IniDataTryAddValueLog"
         if nameExists (name : string) (iniData : IniData) then
-            log.Error($"Name {name} already exists in the config.")
+            log.Info($"Name {name} already exists in the config.")
             Some iniData
         else
             let section,key = splitName name 

--- a/src/ArcCommander/IniData.fs
+++ b/src/ArcCommander/IniData.fs
@@ -148,6 +148,7 @@ module IniData =
     /// Writes the iniData as an ini file to the given location
     let toFile path iniData =
         let parser = Parser.IniDataParser(defaultParserConfiguration) |> FileIniDataParser
+        Directory.CreateDirectory(FileInfo(path).DirectoryName) |> ignore
         parser.WriteFile(path, iniData)
 
     /// If a section with the given name exists in the iniData, returns its keyValue pairs c

--- a/tests/ArcCommander.Tests/ArcTests.fs
+++ b/tests/ArcCommander.Tests/ArcTests.fs
@@ -133,40 +133,40 @@ let testArcExport =
             Expect.sequenceEqual study.RegisteredAssayIdentifiers [assayIdentifier] "Assay was not exported"
 
         )
-        //testCase "OnlyExportRegistered" (fun () ->
-        //    let config = createConfigFromDir testListName "OnlyExportRegistered"
+        testCase "OnlyExportRegistered" (fun () ->
+            let config = createConfigFromDir testListName "OnlyExportRegistered"
 
-        //    let identifier = "MyInvestigation"
-        //    let investigationArgs = [ArcInitArgs.Identifier identifier]
-        //    processCommand config ArcAPI.init investigationArgs
+            let identifier = "MyInvestigation"
+            let investigationArgs = [ArcInitArgs.Identifier identifier]
+            processCommand config ArcAPI.init investigationArgs
 
-        //    let registeredAssayIdentifier =  "RegisteredAssay"
-        //    let assayArgs = [AssayAddArgs.AssayIdentifier registeredAssayIdentifier]
-        //    processCommand config AssayAPI.add assayArgs
+            let registeredAssayIdentifier =  "RegisteredAssay"
+            let assayArgs = [AssayAddArgs.AssayIdentifier registeredAssayIdentifier]
+            processCommand config AssayAPI.add assayArgs
 
-        //    let unregisteredAssayIdentifier = "UnregisteredAssay"
-        //    let assayArgs = [AssayInitArgs.AssayIdentifier unregisteredAssayIdentifier]
-        //    processCommand config AssayAPI.init assayArgs
+            let unregisteredAssayIdentifier = "UnregisteredAssay"
+            let assayArgs = [AssayInitArgs.AssayIdentifier unregisteredAssayIdentifier]
+            processCommand config AssayAPI.init assayArgs
 
-        //    let unregisteredStudyIdentifier = "UnregisteredStudy"
-        //    let studyArgs = [StudyInitArgs.Identifier unregisteredStudyIdentifier]
-        //    processCommand config StudyAPI.init studyArgs
+            let unregisteredStudyIdentifier = "UnregisteredStudy"
+            let studyArgs = [StudyInitArgs.Identifier unregisteredStudyIdentifier]
+            processCommand config StudyAPI.init studyArgs
 
-        //    let exportPath = Path.Combine(GeneralConfiguration.getWorkDirectory config, "export.json")
-        //    let exportArgs = [ArcExportArgs.Output exportPath]
-        //    processCommand config ArcAPI.export exportArgs
+            let exportPath = Path.Combine(GeneralConfiguration.getWorkDirectory config, "export.json")
+            let exportArgs = [ArcExportArgs.Output exportPath]
+            processCommand config ArcAPI.export exportArgs
 
-        //    Expect.isTrue (System.IO.File.Exists exportPath) "Export was not created"
+            Expect.isTrue (System.IO.File.Exists exportPath) "Export was not created"
 
-        //    let isa = Json.ArcInvestigation.fromJsonString (System.IO.File.ReadAllText exportPath)
+            let isa = Json.ArcInvestigation.fromJsonString (System.IO.File.ReadAllText exportPath)
 
-        //    Expect.equal isa.Identifier identifier "Identifier was not set correctly in exported json"
-        //    Expect.equal isa.Studies.Count 1 "Only one study should be exported"
-        //    let study = Expect.wantSome (isa.TryGetStudy registeredAssayIdentifier) "Study was not exported"
+            Expect.equal isa.Identifier identifier "Identifier was not set correctly in exported json"
+            Expect.equal isa.Studies.Count 1 "Only one study should be exported"
+            let study = Expect.wantSome (isa.TryGetStudy registeredAssayIdentifier) "Study was not exported"
 
-        //    Expect.equal isa.AssayCount 1 "Only one assay should be exported"
-        //    Expect.sequenceEqual study.RegisteredAssayIdentifiers [registeredAssayIdentifier] "Assay was not exported"            
-        //)
+            Expect.equal isa.AssayCount 1 "Only one assay should be exported"
+            Expect.sequenceEqual study.RegisteredAssayIdentifiers [registeredAssayIdentifier] "Assay was not exported"            
+        )
     ]
     |> testSequenced
 

--- a/tests/ArcCommander.Tests/AssayTests.fs
+++ b/tests/ArcCommander.Tests/AssayTests.fs
@@ -62,11 +62,12 @@ let testAssayTestFunction =
 
 let testAssayRegister = 
 
-    testList "AssayRegisterTests" [
+    let testListName = "AssayRegister"
+    testList testListName [
 
         testCase "AddToExistingStudy" (fun () -> 
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "AddToExistingStudy"
+            let configuration = createConfigFromDir testListName "AddToExistingStudy"
             setupArc configuration
 
             let assayIdentifier = "TestAssay"
@@ -100,7 +101,7 @@ let testAssayRegister =
         )
         testCase "DoNothingIfAssayExisting" (fun () -> 
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "DoNothingIfAssayExisting"
+            let configuration = createConfigFromDir testListName "DoNothingIfAssayExisting"
             setupArc configuration
 
             let assayIdentifier = "TestAssay"
@@ -142,7 +143,7 @@ let testAssayRegister =
         )
         testCase "AddSecondAssayToExistingStudy" (fun () -> 
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "AddSecondAssayToExistingStudy"
+            let configuration = createConfigFromDir testListName "AddSecondAssayToExistingStudy"
             setupArc configuration
 
             let oldAssayIdentifier = "TestAssay"
@@ -191,7 +192,7 @@ let testAssayRegister =
         )
         testCase "CreateStudyIfNotExisting" (fun () -> 
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "CreateStudyIfNotExisting"
+            let configuration = createConfigFromDir testListName "CreateStudyIfNotExisting"
             setupArc configuration
 
             let assayIdentifier = "TestAssay"
@@ -219,7 +220,7 @@ let testAssayRegister =
         )
         testCase "StudyNameNotGivenUseAssayName" (fun () -> 
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "StudyNameNotGivenUseAssayName"
+            let configuration = createConfigFromDir testListName "StudyNameNotGivenUseAssayName"
             setupArc configuration
 
             let assayIdentifier = "TestAssayWithoutStudyName"
@@ -246,7 +247,7 @@ let testAssayRegister =
         // This case checks if no duplicate study gets created when the user adds an assay with an identifier (and no given study identifier) that equals a previously added study's identifier.
         testCase "StudyNameNotGivenUseAssayNameNoDuplicateStudy" (fun () -> 
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "StudyNameNotGivenUseAssayNameNoDuplicateStudy"
+            let configuration = createConfigFromDir testListName "StudyNameNotGivenUseAssayNameNoDuplicateStudy"
             setupArc configuration
 
             let studyIdentifier = "TestAssayWithoutStudyName"
@@ -272,7 +273,7 @@ let testAssayRegister =
         )
         testCase "StudyNameNotGivenUseAssayNameNoDuplicateAssay" (fun () ->
 
-            let configuration = createConfigFromDir "AssayRegisterTests" "StudyNameNotGivenUseAssayNameNoDuplicateAssay"
+            let configuration = createConfigFromDir testListName "StudyNameNotGivenUseAssayNameNoDuplicateAssay"
             setupArc configuration
 
             let assayIdentifier = "StudyCreatedByAssayRegister"
@@ -294,8 +295,62 @@ let testAssayRegister =
             let assay = study.GetRegisteredAssay assayIdentifier
             Expect.equal study.RegisteredAssayCount 1 "Duplicate Assay added"
         )
+        //testCase "StudyNameNotGivenUseAssayNameDuplicateAssay" (fun () ->
+        //    let config = createConfigFromDir testListName "StudyNameNotGivenUseAssayNameDuplicateAssay"
+        //    setupArc config
+
+        //    let testStudyIdentifier = "TestStudy"
+        //    let studyAddArgs = [StudyAddArgs.Identifier testStudyIdentifier]
+        //    processCommand config StudyAPI.add studyAddArgs
+
+        //    let testAssayIdentifier = "TestAssay"
+        //    let assayAddArgs = [AssayAddArgs.StudyIdentifier testStudyIdentifier; AssayAddArgs.AssayIdentifier testAssayIdentifier]
+        //    processCommand config AssayAPI.add assayAddArgs
+
+        //    let assayRegisterArgs = [AssayRegisterArgs.AssayIdentifier testAssayIdentifier]
+        //    Expect.throws (fun () -> processCommand config AssayAPI.register assayRegisterArgs) "trying to register an assay with an identifier that is already in use by a study which shall NOT work"
+
+        //    let arc = ARC.load(config)
+        //    let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+        //    Expect.equal isa.StudyCount 1 "Duplicate study was added"
+
+        //    let study = Expect.wantSome (isa.TryGetStudy testStudyIdentifier) "Study was not added to the investigation"
+
+        //    Expect.equal study.RegisteredAssayCount 1 "Duplicate Assay added"
+        //)
     ]
     |> testSequenced
+
+let testAssayRemove = 
+    
+    let testListName = "AssayRemove"
+
+    testList testListName [
+        testCase "Simple" (fun () ->
+            let config = createConfigFromDir testListName "Simple"
+            setupArc config
+
+            let studyIdentifier = "MyStudy"
+            let studyAddArgs = [StudyAddArgs.Identifier studyIdentifier]
+            processCommand config StudyAPI.add studyAddArgs
+
+            let assayIdentifier = "MyAssay"
+            let assayAddArgs = [AssayAddArgs.StudyIdentifier studyIdentifier; AssayAddArgs.AssayIdentifier assayIdentifier]
+            processCommand config AssayAPI.add assayAddArgs
+
+            let assayRemoveArgs = [AssayRemoveArgs.AssayIdentifier assayIdentifier]
+            processCommand config AssayAPI.remove assayRemoveArgs
+
+            let arc = ARC.load(config)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa.AssayCount 0 "Assay was not deleted"
+            let study = Expect.wantSome (isa.TryGetStudy studyIdentifier) "Study was removed from the investigation"
+            Expect.equal study.RegisteredAssayIdentifiers.Count 0 "Assay was not unregistered from study"
+        )
+    
+    ]
 
 let testAssayUpdate = 
 
@@ -866,5 +921,6 @@ let assayTests =
         testAssayRegister
         testAssayTestFunction
         testAssayUnregister
-        testAssayUpdate    
+        testAssayUpdate
+        testAssayRemove
     ]

--- a/tests/ArcCommander.Tests/StudyTests.fs
+++ b/tests/ArcCommander.Tests/StudyTests.fs
@@ -17,6 +17,29 @@ let setupArc (arcConfiguration:ArcConfiguration) =
 
     processCommand arcConfiguration ArcAPI.init             arcArgs
 
+let testStudyInit = 
+    
+    let testListName = "StudyInitTests"
+
+    testList testListName [
+        testCase "DoesNotRegister" (fun () ->
+            let config = createConfigFromDir testListName "DoesNotRegister"
+
+            setupArc config
+
+            let studyIdentifier = "TestStudy"
+            let studyArgs = [StudyInitArgs.Identifier studyIdentifier]
+            processCommand config StudyAPI.init studyArgs
+
+            let arc = ARC.load(config)
+            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            Expect.equal isa.Studies.Count 1 "Study was not initialized in ARC"
+            Expect.equal isa.RegisteredStudies.Count 0 "Study was registered to ISA, even though it should not have been"   
+        )
+    
+    
+    ]
+
 let testStudyAdd =
     
     let testListName = "StudyAddTests"
@@ -293,6 +316,7 @@ let testStudyContacts =
 [<Tests>]
 let studyTests = 
     testList "Study" [
+        testStudyInit
         testStudyAdd
         testStudyContacts
     ]


### PR DESCRIPTION
closes #210 
`arc assay remove` does not need a `--studyidentifier` argument anymore. Instead, assays are unregistered from all studies

closes #218 
closes #138 
`arc config set` does now not report unnecessary errors anymore

closes #129 
`arc config edit -l` works now

closes #221 
`arc init` now creates git repo when no branch is given

closes #97 
`arc sync` default commit message is no "sync changes using ARCCommander"

closes #209 
`arc sync` now doesn't spam gitignored file names as `git add .` is used

closes #147 
closes #177 
`arc sync` now pushes to current branch instead of `main`
