### PR TITLE
Increase argu speed

### DIFF
--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -230,7 +230,7 @@ let handleCommand arcConfiguration command =
 let main argv =
 
     try
-        let parser = ArgumentParser.Create<ArcCommand>()
+        let parser = ArgumentParser.Create<ArcCommand>(checkStructure = false)
         
         // Failsafe parsing of all correct argument information
         let safeParseResults = parser.ParseCommandLine(inputs = argv, ignoreMissing = true, ignoreUnrecognized = true)

--- a/tests/ArcCommander.Tests/ConfigurationTests.fs
+++ b/tests/ArcCommander.Tests/ConfigurationTests.fs
@@ -5,9 +5,17 @@ open TestingUtils
 open Fake.IO
 open Fake.IO.Globbing.Operators
 
+  
+let arguments =  
+    testList "ArgumentHandling" [
+        testCase "Structure" (fun () ->
+            Argu.ArgumentParser<ArcCommander.Commands.ArcCommand>.CheckStructure()
+        )   
     
-[<PTests>]
+    ]
+
+[<Tests>]
 let configuration =
     testList "Configuration" [
-        //cleanup
+        arguments
     ]


### PR DESCRIPTION
closes #188 

Argument structure check is now perfomed in build, not in run.

Testing `arc init`
Before:
![image](https://github.com/nfdi4plants/ARCCommander/assets/17880410/1aa4ae0e-ffba-4e14-af49-87eb51872365)

After:
![image](https://github.com/nfdi4plants/ARCCommander/assets/17880410/bc2e661e-5b49-49ec-a08d-8a01f572b0f1)
