### PR TITLE
Add Assay and Study Rename functionality

### DIFF
--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -328,6 +328,29 @@ module AssayAPI =
         else 
             log.Error($"Study with the identifier {studyIdentifier} does not exist.")
 
+
+    let rename (arcConfiguration : ArcConfiguration) (assayArgs : ArcParseResults<AssayRenameArgs>) =
+
+        let log = Logging.createLogger "AssayRenameLog"
+
+        log.Info("Start Assay Rename")
+
+        let assayIdentifier = assayArgs.GetFieldValue AssayRenameArgs.AssayIdentifier
+        let newAssayIdentifier = assayArgs.GetFieldValue AssayRenameArgs.NewAssayIdentifier
+
+        let arc = ARC.load(arcConfiguration)
+        let arcPath = GeneralConfiguration.getWorkDirectory arcConfiguration
+        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+
+        if isa.AssayIdentifiers |> Seq.contains assayIdentifier then
+            if isa.AssayIdentifiers |> Seq.contains newAssayIdentifier then
+                log.Error($"Assay with the identifier {newAssayIdentifier} already exists.")
+            else
+                arc.RenameAssay(arcPath, assayIdentifier, newAssayIdentifier)
+        else 
+            log.Error($"Assay with the identifier {assayIdentifier} does not exist.")
+
+
     /// Moves an assay file from one study group to another (provided by assayArgs).
     let show (arcConfiguration : ArcConfiguration) (assayArgs : ArcParseResults<AssayShowArgs>) =
      
@@ -680,6 +703,7 @@ module AssayAPI =
             log.Info("Start Person List")
 
             let arc = ARC.load(arcConfiguration)
+            
             let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
 
             isa.Assays

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -229,6 +229,27 @@ module StudyAPI =
         delete arcConfiguration (studyArgs.Cast<StudyDeleteArgs>())
         unregister arcConfiguration (studyArgs.Cast<StudyUnregisterArgs>())
 
+    let rename (arcConfiguration : ArcConfiguration) (studyArgs : ArcParseResults<StudyRenameArgs>) = 
+        
+        let log = Logging.createLogger "StudyRenameLog"
+
+        log.Info("Start Study Rename")
+
+        let oldIdentifier = studyArgs.GetFieldValue StudyRenameArgs.StudyIdentifier
+        let newIdentifier = studyArgs.GetFieldValue StudyRenameArgs.NewStudyIdentifier
+
+        let arc = ARC.load(arcConfiguration)
+        let arcPath = GeneralConfiguration.getWorkDirectory arcConfiguration
+        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+
+        if isa.StudyIdentifiers |> Seq.contains oldIdentifier then
+            if isa.StudyIdentifiers |> Seq.contains newIdentifier then
+                log.Error($"Study with identifier {newIdentifier} already exists.")
+            else
+                arc.RenameStudy(arcPath, oldIdentifier, newIdentifier)
+        else 
+            log.Error($"Study with identifier {oldIdentifier} does not exist.")
+
     /// Lists all study identifiers registered in this ARC's investigation file.
     let show (arcConfiguration : ArcConfiguration) (studyArgs : ArcParseResults<StudyShowArgs>) =
 

--- a/src/ArcCommander/CLIArguments/AssayArgs.fs
+++ b/src/ArcCommander/CLIArguments/AssayArgs.fs
@@ -129,6 +129,18 @@ type AssayMoveArgs =
             | AssayIdentifier       _ -> "Name of the assay of interest"
             | TargetStudyIdentifier _ -> "Target study to which the assay should be moved"
 
+/// CLI arguments for renaming assay.
+type AssayRenameArgs = 
+    | [<Mandatory>][<AltCommandLine("-a")>][<Unique>] AssayIdentifier    of assay_identifier     : string
+    | [<Mandatory>][<AltCommandLine("-n")>][<Unique>] NewAssayIdentifier of new_assay_identifier : string
+
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | AssayIdentifier     _ -> "Name of the assay that should be renamed."
+                | NewAssayIdentifier  _ -> "The new unique identifier for the assay."
+
+
 /// CLI arguments for getting the values of a specific assay.
 type AssayShowArgs = AssayEditArgs
 

--- a/src/ArcCommander/CLIArguments/StudyArgs.fs
+++ b/src/ArcCommander/CLIArguments/StudyArgs.fs
@@ -78,6 +78,20 @@ type StudyUnregisterArgs = StudyEditArgs
 // same as `init` because both commands only need to be passed a study identifier
 type StudyRemoveArgs = StudyDeleteArgs
 
+/// CLI arguments for renaming study.
+type StudyRenameArgs =
+    | [<Mandatory>][<AltCommandLine("-s")>][<Unique>] StudyIdentifier of study_identifier : string
+    | [<Mandatory>][<AltCommandLine("-n")>][<Unique>] NewStudyIdentifier of new_study_identifier : string
+        
+        interface IArgParserTemplate with
+            member this.Usage =
+                match this with
+                | StudyIdentifier     _ -> "Name of the study that should be renamed."
+                | NewStudyIdentifier  _ -> "The new unique identifier for the study."
+        
+    
+
+
 /// CLI arguments for getting a study.
 // same as `init` because both commands only need to be passed a study identifier
 type StudyShowArgs = StudyEditArgs

--- a/src/ArcCommander/Commands/AssayCommand.fs
+++ b/src/ArcCommander/Commands/AssayCommand.fs
@@ -18,6 +18,7 @@ type AssayCommand =
     | [<CliPrefix(CliPrefix.None)>] Update      of update_args :        ParseResults<AssayUpdateArgs>
     | [<CliPrefix(CliPrefix.None)>] Edit        of edit_args :          ParseResults<AssayEditArgs>
     | [<CliPrefix(CliPrefix.None)>] Move        of move_args :          ParseResults<AssayMoveArgs>
+    | [<CliPrefix(CliPrefix.None)>] Rename      of rename_args :        ParseResults<AssayRenameArgs>
     //Retrievals
     | [<CliPrefix(CliPrefix.None)>] Show        of show_args :          ParseResults<AssayShowArgs>
     | [<CliPrefix(CliPrefix.None)>] [<SubCommand()>] List
@@ -39,6 +40,7 @@ type AssayCommand =
             | Update            _ -> "Update an existing assay in the ARC with the given assay metadata"
             | Edit              _ -> "Open and edit an existing assay in the ARC with a text editor. Arguments passed for this command will be pre-set in the editor."
             | Move              _ -> "Move an assay from one study to another"
+            | Rename            _ -> "Rename an existing assay in the ARC. This will rename the assay folder and update the assay name in the investigation file."
 
             | Show              _ -> "Gets the values of an existing assay"
             | List                -> "List all assays registered in the ARC"

--- a/src/ArcCommander/Commands/StudyCommand.fs
+++ b/src/ArcCommander/Commands/StudyCommand.fs
@@ -22,6 +22,7 @@ type StudyCommand =
 
     | [<CliPrefix(CliPrefix.None)>] Update      of update_args          : ParseResults<StudyUpdateArgs>
     | [<CliPrefix(CliPrefix.None)>] Edit        of edit_args            : ParseResults<StudyEditArgs>
+    | [<CliPrefix(CliPrefix.None)>] Rename      of rename_args          : ParseResults<StudyRenameArgs>
 
     | [<CliPrefix(CliPrefix.None)>] Show        of show_args            : ParseResults<StudyShowArgs>
     | [<CliPrefix(CliPrefix.None)>] [<SubCommand()>] List 
@@ -43,6 +44,7 @@ type StudyCommand =
             | Remove        _ -> "Remove a study from the ARC (delete the study and unregister it from the investigation file)"
             | Update        _ -> "Update an existing study in the ARC with the given study metadata"
             | Edit          _ -> "Open and edit an existing study in the ARC with a text editor. Arguments passed for this command will be pre-set in the editor."
+            | Rename        _ -> "Rename an existing study in the ARC"
             | Show          _ -> "Get the values of a study"
             | List            -> "List all studies registered in the ARC"
             | Person        _ -> "Person functions"

--- a/tests/ArcCommander.Tests/AssayTests.fs
+++ b/tests/ArcCommander.Tests/AssayTests.fs
@@ -712,7 +712,108 @@ let testAssayMove =
     ]
     |> testSequenced
 
+let testAssayRename = 
+    testList "AssayRenameTests" [
 
+        testCase "Standard" (fun () ->
+        
+            let configuration = createConfigFromDir "AssayRenameTests" "Standard"
+            setupArc configuration
+
+            let assayIdentifier = "MyAssay"
+            let measurementType = "MyMeasurementType"
+            let targetAssayIdentifier = "NewAssayName"
+        
+            let assayInitArgs : AssayInitArgs list = [
+                AssayInitArgs.AssayIdentifier assayIdentifier
+                AssayInitArgs.MeasurementType measurementType
+            ]
+
+            processCommand configuration AssayAPI.init assayInitArgs
+
+            let assayRenameArgs : AssayRenameArgs list = [
+                AssayRenameArgs.AssayIdentifier assayIdentifier
+                AssayRenameArgs.NewAssayIdentifier targetAssayIdentifier
+            ]
+
+            processCommand configuration AssayAPI.rename assayRenameArgs
+
+            let arc = ARC.load(configuration)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa.AssayCount 1 "Assay count is incorrect after renaming assay"
+
+            let assay = Expect.wantSome (isa.TryGetAssay targetAssayIdentifier) "Renamed assay could not be found with new identifier"
+
+            Expect.equal assay.Identifier targetAssayIdentifier "Assay identifier was not updated correctly"
+
+            let mt = Expect.wantSome assay.MeasurementType "Assay measurement type was removed during renaming"
+
+            Expect.equal mt.NameText measurementType "Assay measurement type was changed during renaming"
+        )
+
+        testCase "TargetAlreadyExists" (fun () ->
+        
+            let configuration = createConfigFromDir "AssayRenameTests" "TargetAlreadyExists"
+            setupArc configuration
+
+            let assayIdentifier = "MyAssay"
+            let targetAssayIdentifier = "NewAssayName"
+        
+            let assayInitArgs1 : AssayInitArgs list = [
+                AssayInitArgs.AssayIdentifier assayIdentifier
+            ]
+
+            let assayInitArgs2 : AssayInitArgs list = [
+                AssayInitArgs.AssayIdentifier targetAssayIdentifier
+            ]
+
+            processCommand configuration AssayAPI.init assayInitArgs1
+            processCommand configuration AssayAPI.init assayInitArgs2
+
+            let arcBeforeUpdate = ARC.load(configuration)
+            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+
+            Expect.equal isaBeforeUpdate.AssayCount 2 "Assay count is incorrect before renaming assay"
+
+            let assayRenameArgs : AssayRenameArgs list = [
+                AssayRenameArgs.AssayIdentifier assayIdentifier
+                AssayRenameArgs.NewAssayIdentifier targetAssayIdentifier
+            ]
+
+            processCommand configuration AssayAPI.rename assayRenameArgs          
+            
+            let arc = ARC.load(configuration)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa isaBeforeUpdate "Investigation values did change even though the target assay identifier already exists and no renaming should have happened"
+        )
+
+        testCase "AssayDoesNotExist" (fun () ->
+            let configuration = createConfigFromDir "AssayRenameTests" "AssayDoesNotExist"
+            setupArc configuration
+
+            let assayIdentifier = "NonExistingAssay"
+            let targetAssayIdentifier = "NewAssayName"
+
+            let assayArgs : AssayRenameArgs list = [
+                AssayRenameArgs.AssayIdentifier assayIdentifier
+                AssayRenameArgs.NewAssayIdentifier targetAssayIdentifier
+            ]
+
+            let arcBeforeUpdate = ARC.load(configuration)
+            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+
+            processCommand configuration AssayAPI.rename assayArgs
+
+            let arc = ARC.load(configuration)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given assay does not exist and none should have been renamed"
+                    
+        )
+    
+    ]
 
 let testAssayPerformers = 
 
@@ -920,4 +1021,5 @@ let assayTests =
         testAssayUnregister
         testAssayUpdate
         testAssayRemove
+        testAssayRename
     ]

--- a/tests/ArcCommander.Tests/StudyTests.fs
+++ b/tests/ArcCommander.Tests/StudyTests.fs
@@ -241,6 +241,108 @@ let testStudyAdd =
     //]
     //|> testSequenced
 
+let testStudyRename = 
+    testList "StudyRenameTests" [
+
+        testCase "Standard" (fun () ->
+        
+            let configuration = createConfigFromDir "StudyRenameTests" "Standard"
+            setupArc configuration
+
+            let studyIdentifier = "MyStudy"
+            let description = "MyDescription"
+            let targetStudyIdentifier = "NewStudyName"
+        
+            let studyInitArgs : StudyInitArgs list = [
+                StudyInitArgs.StudyIdentifier studyIdentifier
+                StudyInitArgs.Description description
+            ]
+
+            processCommand configuration StudyAPI.init studyInitArgs
+
+            let studyRenameArgs : StudyRenameArgs list = [
+                StudyRenameArgs.StudyIdentifier studyIdentifier
+                StudyRenameArgs.NewStudyIdentifier targetStudyIdentifier
+            ]
+
+            processCommand configuration StudyAPI.rename studyRenameArgs
+
+            let arc = ARC.load(configuration)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa.StudyCount 1 "Study count is incorrect after renaming study"
+
+            let study = Expect.wantSome (isa.TryGetStudy targetStudyIdentifier) "Renamed study could not be found with new identifier"
+
+            Expect.equal study.Identifier targetStudyIdentifier "Study identifier was not updated correctly"
+
+            let d = Expect.wantSome study.Description "Study description was removed during renaming"
+
+            Expect.equal d description "Study description was changed during renaming"
+        )
+
+        testCase "TargetAlreadyExists" (fun () ->
+        
+            let configuration = createConfigFromDir "StudyRenameTests" "TargetAlreadyExists"
+            setupArc configuration
+
+            let studyIdentifier = "MyStudy"
+            let targetStudyIdentifier = "NewStudyName"
+        
+            let studyInitArgs1 : StudyInitArgs list = [
+                StudyInitArgs.StudyIdentifier studyIdentifier
+            ]
+
+            let studyInitArgs2 : StudyInitArgs list = [
+                StudyInitArgs.StudyIdentifier targetStudyIdentifier
+            ]
+
+            processCommand configuration StudyAPI.init studyInitArgs1
+            processCommand configuration StudyAPI.init studyInitArgs2
+
+            let arcBeforeUpdate = ARC.load(configuration)
+            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+
+            Expect.equal isaBeforeUpdate.StudyCount 2 "Study count is incorrect before renaming study"
+
+            let studyRenameArgs : StudyRenameArgs list = [
+                StudyRenameArgs.StudyIdentifier studyIdentifier
+                StudyRenameArgs.NewStudyIdentifier targetStudyIdentifier
+            ]
+
+            processCommand configuration StudyAPI.rename studyRenameArgs          
+            
+            let arc = ARC.load(configuration)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa isaBeforeUpdate "Investigation values did change even though the target study identifier already exists and no renaming should have happened"
+        )
+
+        testCase "StudyDoesNotExist" (fun () ->
+            let configuration = createConfigFromDir "StudyRenameTests" "StudyDoesNotExist"
+            setupArc configuration
+
+            let studyIdentifier = "NonExistingStudy"
+            let targetStudyIdentifier = "NewStudyName"
+
+            let studyArgs : StudyRenameArgs list = [
+                StudyRenameArgs.StudyIdentifier studyIdentifier
+                StudyRenameArgs.NewStudyIdentifier targetStudyIdentifier
+            ]
+
+            let arcBeforeUpdate = ARC.load(configuration)
+            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+
+            processCommand configuration StudyAPI.rename studyArgs
+
+            let arc = ARC.load(configuration)
+            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+
+            Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given study does not exist and none should have been renamed"
+                    
+        )
+    
+    ]    
 
 let testStudyContacts = 
 
@@ -325,5 +427,6 @@ let studyTests =
     testList "Study" [
         testStudyInit
         testStudyAdd
+        testStudyRename
         testStudyContacts
     ]


### PR DESCRIPTION

## arc assay rename
```shell
PS C:\Users\HLWei> arc a rename --help

USAGE: arc.exe assay rename [--help] --assayidentifier <assay identifier> --newassayidentifier <new assay identifier>

OPTIONS:

    --assayidentifier, -a <assay identifier>
                          Name of the assay that should be renamed.
    --newassayidentifier, -n <new assay identifier>
                          The new unique identifier for the assay.
    --help, -h            display this list of options.
```

## arc study rename
```shell
PS C:\Users\HLWei> arc s rename --help

USAGE: arc.exe study rename [--help] --studyidentifier <study identifier> --newstudyidentifier <new study identifier>

OPTIONS:

    --studyidentifier, -s <study identifier>
                          Name of the study that should be renamed.
    --newstudyidentifier, -n <new study identifier>
                          The new unique identifier for the study.
    --help, -h            display this list of options.
```
