### PR TITLE
Change arc get so that downloading lfs files is not the default behavior

### DIFF
--- a/src/ArcCommander/APIs/GitAPI.fs
+++ b/src/ArcCommander/APIs/GitAPI.fs
@@ -38,10 +38,10 @@ module GitAPI =
             | None -> ""
 
         let lfsConfig = 
-            if arcArgs.ContainsFlag ArcGetArgs.NoLFS then
-                $" {GitHelper.noLFSConfig}"
-            else
+            if arcArgs.ContainsFlag ArcGetArgs.LFS then
                 ""
+            else
+                $" {GitHelper.noLFSConfig}"
 
         if merge then
             log.Trace("Downloading into current folder.")

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -81,7 +81,7 @@ type ArcGetArgs =
             match this with
             | RepositoryAddress _ -> "Git remote address from which to pull the ARC"
             | BranchName        _ -> "Branch of the remote address which should be used. If none is given, uses \"main\""
-            | LFS                 -> "Does download not only the pointers of LFS files, but also the file content itself. Leaving this flag away is ideal for when you're only interested in the experimental metadata, not the data itself. You should use this flag when you want to actually do analysis or just explore the data."
+            | LFS                 -> "Downloads not only the pointers of LFS files, but also the file content itself. Leaving this flag away is ideal for when you are only interested in experimental metadata, not the data itself. You should use this flag when you want to actually work with the data."
             | Merge               -> "Merges the repository into the current folder. Fails, if the current folder isn't empty."
 
 type ArcServerArgs =

--- a/src/ArcCommander/CLIArguments/ArcArgs.fs
+++ b/src/ArcCommander/CLIArguments/ArcArgs.fs
@@ -73,7 +73,7 @@ type ArcSyncArgs =
 type ArcGetArgs =
     | [<Mandatory>][<Unique>][<AltCommandLine("-r")>] RepositoryAddress of repository_address:string
     | [<Unique>][<AltCommandLine("-b")>] BranchName         of branch_name:string
-    | [<Unique>][<AltCommandLine("-n")>] NoLFS
+    | [<Unique>][<AltCommandLine("-l")>] LFS
     | [<Unique>][<AltCommandLine("-m")>] Merge
 
     interface IArgParserTemplate with
@@ -81,7 +81,7 @@ type ArcGetArgs =
             match this with
             | RepositoryAddress _ -> "Git remote address from which to pull the ARC"
             | BranchName        _ -> "Branch of the remote address which should be used. If none is given, uses \"main\""
-            | NoLFS               -> "Does download only the pointers of LFS files, not the file content itself. Ideal for when you're only interested in the experimental metadata, not the data itself."
+            | LFS                 -> "Does download not only the pointers of LFS files, but also the file content itself. Leaving this flag away is ideal for when you're only interested in the experimental metadata, not the data itself. You should use this flag when you want to actually do analysis or just explore the data."
             | Merge               -> "Merges the repository into the current folder. Fails, if the current folder isn't empty."
 
 type ArcServerArgs =


### PR DESCRIPTION
closes #253 

```shell
PS C:\Users\HLWei\source\repos\other> arc get --help

USAGE: arc.exe get [--help] --repositoryaddress <repository address> [--branchname <branch name>] [--lfs] [--merge]

OPTIONS:

    --repositoryaddress, -r <repository address>
                          Git remote address from which to pull the ARC
    --branchname, -b <branch name>
                          Branch of the remote address which should be used. If none is given, uses "main"
    --lfs, -l             Does download not only the pointers of LFS files, but also the file content itself. Leaving
                          this flag away is ideal for when you're only interested in the experimental metadata, not
                          the data itself. You should use this flag when you want to actually do analysis or just
                          explore the data.
    --merge, -m           Merges the repository into the current folder. Fails, if the current folder isn't empty.
    --help, -h            display this list of options.
```

