### PR TITLE
Output text color

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,3 @@
 @echo off
-cls
 
 dotnet run --project ./build/Build.fsproj %*

--- a/build/PackageTasks.fs
+++ b/build/PackageTasks.fs
@@ -57,8 +57,9 @@ let publishBinaryInPath (path : string) (version : string) (versionSuffix : stri
                             "Platform", runtime.GetPlatform()
                             "PublishSingleFile", "true"
                         ]
-                }               
-        }        
+                        DisableInternalBinLog = true
+                }
+        }
     )
 
 let publishBinary (version : string) (versionSuffix : string Option) (runtime : RunTime) = 

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -35,27 +35,44 @@ module API =
 /// ArcCommander API functions that get executed by top level subcommand verbs.
 module ArcAPI = 
 
+    /// Gets the ArcCommander's current version and displays it.
     let version _ =
-        
+
         let log = Logging.createLogger "ArcVersionLog"
 
-        log.Info($"Start Arc Version")
-        
+        log.Info("Start Arc Version")
+
         let assembly = Reflection.Assembly.GetExecutingAssembly()
-            
+
         let productVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion
-        
+
         if productVersion.Contains "-" then 
             log.Debug($"v{productVersion}")
         else 
             let fv = assembly.GetName().Version
             log.Debug($"v{fv.Major}.{fv.Minor}.{fv.Build}")
 
+
+    /// Displays test messages at different log levels.
+    let testMessage _ =
+
+        let log = Logging.createLogger "ArcTestMessageLog"
+
+        //log.Info("Start Arc TestMessage")
+
+        log.Info("This is an Info message")
+        log.Trace("This is a Trace message")
+        log.Debug("This is a Debug message")
+        log.Warn("This is a Warning message")
+        log.Error("This is an Error message")
+        log.Fatal("This is a Fatal Error message")
+
+
     /// Initializes the ARC-specific folder structure.
     let init (arcConfiguration : ArcConfiguration) (arcArgs : ArcParseResults<ArcInitArgs>) =
 
         let log = Logging.createLogger "ArcInitLog"
-        
+
         log.Info("Start Arc Init")
 
         let workDir = GeneralConfiguration.getWorkDirectory arcConfiguration
@@ -64,9 +81,9 @@ module ArcAPI =
         let gitLFSThreshold     = arcArgs.TryGetFieldValue ArcInitArgs.GitLFSByteThreshold 
         let branch              = arcArgs.TryGetFieldValue ArcInitArgs.Branch |> Option.defaultValue GitHelper.defaultBranch
         let repositoryAddress   = arcArgs.TryGetFieldValue ArcInitArgs.RepositoryAddress 
-        let identifier =    
+        let identifier =
             arcArgs.TryGetFieldValue ArcInitArgs.InvestigationIdentifier
-            |> Option.defaultValue (DirectoryInfo(workDir).Name)       
+            |> Option.defaultValue (DirectoryInfo(workDir).Name)
 
         log.Trace("Create Directory")
 
@@ -75,7 +92,7 @@ module ArcAPI =
         log.Trace("Initiate folder structure")
 
         let isa = ArcInvestigation.create(identifier)
-        ARC(isa).Write(arcConfiguration)     
+        ARC(isa).Write(arcConfiguration)
 
         GeneralConfiguration.tryGetRootfolder arcConfiguration
         |> Option.iter (fun p -> 
@@ -83,7 +100,7 @@ module ArcAPI =
             Directory.CreateDirectory dir |> ignore
             let p = Path.Combine(dir,".gitkeep")
             File.WriteAllText(p,"")
-        )       
+        )
 
         log.Trace("Set configuration")
 

--- a/src/ArcCommander/Commands/ArcCommand.fs
+++ b/src/ArcCommander/Commands/ArcCommand.fs
@@ -6,7 +6,7 @@ open ArcCommander.CLIArguments
 [<HelpFlags([|"--help"; "-h"|])>]
 type ArcCommand =
     ///Parameters
-    | [<AltCommandLine("-p")>][<Unique>]                        WorkingDir  of working_directory : string
+    | [<AltCommandLine("-p")>][<Unique>]                        WorkingDir      of working_directory : string
     | [<AltCommandLine("-v")>][<Unique>]                        Verbosity       of verbosity : int
     ///Commands
     | [<CliPrefix(CliPrefix.None)>]                             Init            of init_args    : ParseResults<ArcInitArgs>

--- a/src/ArcCommander/Commands/ArcCommand.fs
+++ b/src/ArcCommander/Commands/ArcCommand.fs
@@ -17,6 +17,7 @@ type ArcCommand =
     | [<CliPrefix(CliPrefix.None)>]                             Server          of server_args  : ParseResults<ArcServerArgs>
     | [<CliPrefix(CliPrefix.None)>][<SubCommand()>]             Update
     | [<AltCommandLine("--version")>][<CliPrefix(CliPrefix.None)>][<SubCommand()>] Version
+    | [<AltCommandLine("--testmessage")>][<CliPrefix(CliPrefix.None)>][<SubCommand()>] TestMessage
     ///Subcommands
     | [<AltCommandLine("i")>][<CliPrefix(CliPrefix.None)>]      Investigation   of verb_and_args : ParseResults<InvestigationCommand>
     | [<AltCommandLine("s")>][<CliPrefix(CliPrefix.None)>]      Study           of verb_and_args : ParseResults<StudyCommand>
@@ -41,4 +42,5 @@ type ArcCommand =
             | Assay         _   -> "Assay functions"
             | Configuration _   -> "Configuration editing"
             | Version           -> "Get the ArcCommander's current version"
+            | TestMessage       -> "Display a test message to check for correct coloring"
             | Server        _   -> "Start the ArcCommander as a local server"

--- a/src/ArcCommander/Logging.fs
+++ b/src/ArcCommander/Logging.fs
@@ -89,7 +89,7 @@ module Logging =
         config.AddRuleForOneLevel(LogLevel.Error, fileTarget)
         config.AddRuleForOneLevel(LogLevel.Fatal, consoleTarget2) // fatal errors shall be used for critical events that cause ArcCommander exceptions leading to an unsuccessful termination
         config.AddRuleForOneLevel(LogLevel.Fatal, fileTarget) // impairing the ARC structure
-   
+
         // activate config for logger
         LogManager.Configuration <- config
 
@@ -98,10 +98,10 @@ module Logging =
         if output = null then ""
         elif output.EndsWith('\n') then reviseOutput (output.[0 .. output.Length - 2])
         else output
-    
+
     /// Checks if an error message coming from CMD not being able to call a program with the given name.
     let matchCmdErrMsg (errMsg : string) = errMsg.Contains("is not recognized as an internal or external command")
-    
+
     /// Checks if an error message coming from Bash not being able to call a program with the given name.
     let matchBashErrMsg (errMsg : string) = errMsg.Contains("bash: ") && errMsg.Contains("command not found") || errMsg.Contains("No such file or directory")
 
@@ -131,6 +131,6 @@ module Logging =
         | true,false,false -> printfn "%s" exn.Message // exception message contains usage message but NO error message
         | false,false,true -> () // empty error message
         | _ -> log.Error(exn) // everything else will be a non-empty error message
-    
+
     /// Checks if a message (string) is empty and if it is not, applies a logging function to it.
     let checkNonLog s (logging : string -> unit) = if s <> "" then logging s

--- a/src/ArcCommander/Logging.fs
+++ b/src/ArcCommander/Logging.fs
@@ -15,28 +15,6 @@ open NLog.Conditions
 /// Functions for working with the NLog logger.
 module Logging =
 
-    let toDarkOutputColor (consoleTarget : ColoredConsoleTarget) consoleColor =
-        match (consoleColor : ConsoleColor) with
-        | ConsoleColor.White
-        | ConsoleColor.Cyan
-        | ConsoleColor.Yellow
-        | ConsoleColor.Gray ->
-            let debugColorRule = new ConsoleRowHighlightingRule()
-            debugColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Debug")
-            debugColorRule.ForegroundColor <- ConsoleOutputColor.Black
-            consoleTarget.RowHighlightingRules.Add(debugColorRule)
-
-            let traceColorRule = new ConsoleRowHighlightingRule()
-            traceColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Trace")
-            traceColorRule.ForegroundColor <- ConsoleOutputColor.Black
-            consoleTarget.RowHighlightingRules.Add(traceColorRule)
-
-            let infoColorRule = new ConsoleRowHighlightingRule()
-            infoColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Info")
-            infoColorRule.ForegroundColor <- ConsoleOutputColor.Black
-            consoleTarget.RowHighlightingRules.Add(infoColorRule)
-        | _ -> ()
-
     /// Generates an NLog config with `folderPath` being the output folder for the log file.
     let generateConfig (folderPath : string) consoleColor verbosity = 
         // initialize base configuration class, can be modified
@@ -70,6 +48,15 @@ module Logging =
         config.AddTarget(fileTarget)
 
         // define rules for colors that shall differ from the default color theme
+        let debugColorRule = new ConsoleRowHighlightingRule()
+        debugColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Debug")
+        debugColorRule.ForegroundColor <- ConsoleOutputColor.Black
+        let traceColorRule = new ConsoleRowHighlightingRule()
+        traceColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Trace")
+        traceColorRule.ForegroundColor <- ConsoleOutputColor.Black
+        let infoColorRule = new ConsoleRowHighlightingRule()
+        infoColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Info")
+        infoColorRule.ForegroundColor <- ConsoleOutputColor.Black
         let warnColorRule = new ConsoleRowHighlightingRule()
         warnColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Warn")
         warnColorRule.ForegroundColor <- ConsoleOutputColor.Yellow
@@ -82,12 +69,12 @@ module Logging =
         fatalColorRule.BackgroundColor <- ConsoleOutputColor.DarkYellow
 
         // add the newly defined rules to the console target
+        consoleTarget1.RowHighlightingRules.Add(infoColorRule)
+        consoleTarget1.RowHighlightingRules.Add(traceColorRule)
+        consoleTarget1.RowHighlightingRules.Add(debugColorRule)
         consoleTarget2.RowHighlightingRules.Add(errorColorRule)
         consoleTarget2.RowHighlightingRules.Add(fatalColorRule)
         consoleTarget3.RowHighlightingRules.Add(warnColorRule)
-
-        // define and add color rules if terminal background is (rather) bright
-        toDarkOutputColor consoleTarget1 consoleColor
 
         // declare which results in a log in which target
         if verbosity >= 1 then config.AddRuleForOneLevel(LogLevel.Info, consoleTarget1) // info results shall be used for verbosity 1

--- a/src/ArcCommander/Logging.fs
+++ b/src/ArcCommander/Logging.fs
@@ -15,8 +15,30 @@ open NLog.Conditions
 /// Functions for working with the NLog logger.
 module Logging =
 
+    let toDarkOutputColor (consoleTarget : ColoredConsoleTarget) consoleColor =
+        match (consoleColor : ConsoleColor) with
+        | ConsoleColor.White
+        | ConsoleColor.Cyan
+        | ConsoleColor.Yellow
+        | ConsoleColor.Gray ->
+            let debugColorRule = new ConsoleRowHighlightingRule()
+            debugColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Debug")
+            debugColorRule.ForegroundColor <- ConsoleOutputColor.Black
+            consoleTarget.RowHighlightingRules.Add(debugColorRule)
+
+            let traceColorRule = new ConsoleRowHighlightingRule()
+            traceColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Trace")
+            traceColorRule.ForegroundColor <- ConsoleOutputColor.Black
+            consoleTarget.RowHighlightingRules.Add(traceColorRule)
+
+            let infoColorRule = new ConsoleRowHighlightingRule()
+            infoColorRule.Condition <- ConditionParser.ParseExpression("level == LogLevel.Info")
+            infoColorRule.ForegroundColor <- ConsoleOutputColor.Black
+            consoleTarget.RowHighlightingRules.Add(infoColorRule)
+        | _ -> ()
+
     /// Generates an NLog config with `folderPath` being the output folder for the log file.
-    let generateConfig (folderPath : string) verbosity = 
+    let generateConfig (folderPath : string) consoleColor verbosity = 
         // initialize base configuration class, can be modified
         let config = new LoggingConfiguration()
 
@@ -63,6 +85,9 @@ module Logging =
         consoleTarget2.RowHighlightingRules.Add(errorColorRule)
         consoleTarget2.RowHighlightingRules.Add(fatalColorRule)
         consoleTarget3.RowHighlightingRules.Add(warnColorRule)
+
+        // define and add color rules if terminal background is (rather) bright
+        toDarkOutputColor consoleTarget1 consoleColor
 
         // declare which results in a log in which target
         if verbosity >= 1 then config.AddRuleForOneLevel(LogLevel.Info, consoleTarget1) // info results shall be used for verbosity 1

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -218,6 +218,7 @@ let handleCommand arcConfiguration command =
     | Server r                  -> processCommand                   arcConfiguration Server.start r
     | Update                    -> processCommandWithoutArgs        arcConfiguration ArcAPI.update
     | Version                   -> processCommandWithoutArgs        arcConfiguration ArcAPI.version
+    | TestMessage               -> processCommandWithoutArgs        arcConfiguration ArcAPI.testMessage
     // Git Verbs
     | Sync r                    -> processCommand                   arcConfiguration GitAPI.sync r
     | Get r                     -> processCommand                   arcConfiguration GitAPI.get r
@@ -228,9 +229,11 @@ let handleCommand arcConfiguration command =
 [<EntryPoint>]
 let main argv =
 
+    let consoleBgColor = Console.BackgroundColor
+
     try
         let parser = ArgumentParser.Create<ArcCommand>(checkStructure = false)
-        
+
         // Failsafe parsing of all correct argument information
         let safeParseResults = parser.ParseCommandLine(inputs = argv, ignoreMissing = true, ignoreUnrecognized = true)
 
@@ -251,12 +254,12 @@ let main argv =
             |> IniData.fromNameValuePairs
             |> ArcConfiguration.load
         // <-----
-        
+
         let arcCommanderDataFolder = IniData.createDataFolder ()
         let arcDataFolder = 
             tryGetArcDataFolderPath workingDir arcCommanderDataFolder
             |> Option.defaultValue arcCommanderDataFolder
-        Logging.generateConfig arcDataFolder (GeneralConfiguration.getVerbosity arcConfiguration)
+        Logging.generateConfig arcDataFolder consoleBgColor (GeneralConfiguration.getVerbosity arcConfiguration)
         let log = Logging.createLogger "ArcCommanderMainLog"
 
         log.Trace("Start ArcCommander")
@@ -279,7 +282,7 @@ let main argv =
             1
 
     with e1 ->
-        
+
         let currDir = Directory.GetCurrentDirectory()
 
         // check for existence of an ARC-specific log file:
@@ -288,13 +291,13 @@ let main argv =
             let arcDataFolder = 
                 tryGetArcDataFolderPath currDir arcCommanderDataFolder
                 |> Option.defaultValue arcCommanderDataFolder
-            Logging.generateConfig arcDataFolder 0
+            Logging.generateConfig arcDataFolder consoleBgColor 0
 
         // create logging config, create .arc folder if not already existing:
         with _ ->
             let arcFolder = Path.Combine(currDir, ".arc")
             Directory.CreateDirectory(arcFolder) |> ignore
-            Logging.generateConfig arcFolder 0 
+            Logging.generateConfig arcFolder consoleBgColor 0 
         
         let log = Logging.createLogger "ArcCommanderMainLog"
 


### PR DESCRIPTION
This PR
- adds changes which defines the output text color depending on the background color of the terminal
  - might close #233 (tests on Debian needed)
- adds a test message function related to that (`arc --testmessage`)
- sets `DisableBinLogFile` to `true` for `publishBinariesWin` build task info