### PR TITLE
Migrate ARCCommander to ARCtrl 3.1.0

### DIFF
--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -25,13 +25,14 @@
 
   <ItemGroup>
 	<PackageReference Include="BlackFox.Fake.BuildTask" Version="0.1.3" />
-  	<PackageReference Include="Fake.Core.Target" Version="6.0.0" />
-  	<PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
-  	<PackageReference Include="Fake.Extensions.Release" Version="0.3.1" />
-  	<PackageReference Include="Fake.Core.UserInput" Version="6.0.0" />
-	  <PackageReference Include="Fake.DotNet.Cli" Version="6.0.0" />
-	  <PackageReference Include="Fake.DotNet.MSBuild" Version="6.0.0" />
-	  <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
+    <PackageReference Update="FSharp.Core" Version="10.0.101" />
+  	<PackageReference Include="Fake.Core.Target" Version="6.1.4" />
+  	<PackageReference Include="Fake.IO.FileSystem" Version="6.1.4" />
+  	<PackageReference Include="Fake.Extensions.Release" Version="1.0.0" />
+  	<PackageReference Include="Fake.Core.UserInput" Version="6.1.4" />
+	  <PackageReference Include="Fake.DotNet.Cli" Version="6.1.4" />
+	  <PackageReference Include="Fake.DotNet.MSBuild" Version="6.1.4" />
+	  <PackageReference Include="Fake.Tools.Git" Version="6.1.4" />
   </ItemGroup>
 	
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/ArcCommander/APIs/ArcAPI.fs
+++ b/src/ArcCommander/APIs/ArcAPI.fs
@@ -15,20 +15,16 @@ module API =
         
         open ARCtrl.Process.Conversion
 
-        let getProcesses (arc : ARC) =
-            match arc.ISA with
-            | Some inv ->
+        let getProcesses (arc : ARC) = //updated
+            let studyProcs = 
+                arc.Studies
+                |> Seq.collect (fun s -> s.GetProcesses())
+            let assayProcs = 
+                arc.Assays
+                |> Seq.collect (fun a -> a.GetProcesses())
+            Seq.append studyProcs assayProcs
+            |> Seq.toList
 
-                let studyProcs = 
-                    inv.Studies
-                    |> Seq.collect (fun s -> s.GetProcesses())
-                let assayProcs =
-                    inv.Assays
-                    |> Seq.collect (fun a -> a.GetProcesses())
-                Seq.append studyProcs assayProcs
-                |> Seq.toList
-
-            | None -> []
             
 
 
@@ -75,7 +71,7 @@ module ArcAPI =
         log.Trace("Initiate folder structure")
 
         let isa = ArcInvestigation.create(identifier)
-        ARC(isa).Write(arcConfiguration)     
+        ARC(isa.Identifier).Write(arcConfiguration)     
 
         GeneralConfiguration.tryGetRootfolder arcConfiguration
         |> Option.iter (fun p -> 
@@ -132,10 +128,7 @@ module ArcAPI =
         log.Info("Start Arc Update")
 
         let arc = ARC.load(arcConfiguration)
-        arc.ISA
-        |> Option.iter (fun isa -> 
-            isa.UpdateIOTypeByEntityID()
-        )
+        arc.UpdateIOTypeByEntityID() //simplified
         arc.Update(arcConfiguration)
 
     /// Export the complete ARC as a JSON object.
@@ -154,7 +147,7 @@ module ArcAPI =
                 API.ARC.getProcesses arc
                 |> ARCtrl.Json.ProcessSequence.toISAJsonString(2)
             else 
-                arc.ISA.Value.ToISAJsonString(2)
+                arc.ToISAJsonString(2)
 
         match arcArgs.TryGetFieldValue Output with
         | Some p -> 

--- a/src/ArcCommander/APIs/AssayAPI.fs
+++ b/src/ArcCommander/APIs/AssayAPI.fs
@@ -68,14 +68,14 @@ module AssayAPI =
         let assay = 
             ArcAssay.create(assayIdentifier, ?measurementType = mt,?technologyType = tt, ?technologyPlatform = tp)
         
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.AssayIdentifiers |> Array.contains assayIdentifier then
             log.Error($"Assay with identifier {assayIdentifier} already exists.")
         else
         isa.AddAssay(assay)
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
     /// Updates an existing assay file in the ARC with the given assay metadata contained in cliArgs.
@@ -89,21 +89,40 @@ module AssayAPI =
         let addIfMissing = assayArgs.ContainsFlag AssayUpdateArgs.AddIfMissing
         
         let assayIdentifier = assayArgs.GetFieldValue  AssayUpdateArgs.AssayIdentifier
-        
-        let assay = 
+
+
+        // updated val fromString:
+        //    identifier        : option<string> ->
+        //    title             : option<string> ->
+        //    description       : option<string> ->
+        //    measurementType   : option<string> ->
+        //    measurementTypeTermSourceREF: option<string> ->
+        //    measurementTypeTermAccessionNumber: option<string> ->
+        //    technologyType    : option<string> ->
+        //    technologyTypeTermSourceREF: option<string> ->
+        //    technologyTypeTermAccessionNumber: option<string> ->
+        //    technologyPlatform: option<string> ->
+        //    fileName          : option<string> ->
+        //    comments          : ResizeArray<Comment>
+        //                     -> ArcAssay
+        let assay :ArcAssay = //fixed
             Assays.fromString
+                (Some assayIdentifier)
+                None // do we want to expose those fields?
+                None //same here
                 (assayArgs.TryGetFieldValue  AssayUpdateArgs.MeasurementType)
-                (assayArgs.TryGetFieldValue  AssayUpdateArgs.MeasurementTypeTermAccessionNumber)
                 (assayArgs.TryGetFieldValue  AssayUpdateArgs.MeasurementTypeTermSourceREF)
+                (assayArgs.TryGetFieldValue  AssayUpdateArgs.MeasurementTypeTermAccessionNumber)
                 (assayArgs.TryGetFieldValue  AssayUpdateArgs.TechnologyType)
-                (assayArgs.TryGetFieldValue  AssayUpdateArgs.TechnologyTypeTermAccessionNumber)
                 (assayArgs.TryGetFieldValue  AssayUpdateArgs.TechnologyTypeTermSourceREF)
+                (assayArgs.TryGetFieldValue  AssayUpdateArgs.TechnologyTypeTermAccessionNumber)
                 (assayArgs.TryGetFieldValue  AssayUpdateArgs.TechnologyPlatform)
-                assayIdentifier
+                None
                 (ResizeArray())
-   
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            
+
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         let msg = $"Assay with the identifier {assayIdentifier} does not exist."
         try 
@@ -118,7 +137,7 @@ module AssayAPI =
             log.Error($"{msg}")
             log.Trace("AddIfMissing argument can be used to register assay with the update command if it is missing.")
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
     /// Opens an existing assay file in the ARC with the text editor set in globalArgs, additionally setting the given assay metadata contained in assayArgs.
@@ -139,8 +158,8 @@ module AssayAPI =
                 (Assays.fromRows None 1 >> fun (_,_,_,items) -> items.Head) 
                 oldAssay
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         try 
             let assay = isa.GetAssay assayIdentifier
@@ -150,7 +169,7 @@ module AssayAPI =
         | _ ->
             log.Error($"Assay with the identifier {assayIdentifier} does not exist.")
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
 
@@ -163,8 +182,8 @@ module AssayAPI =
 
         let assayIdentifier = assayArgs.GetFieldValue AssayRegisterArgs.AssayIdentifier
                 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         let studyIdentifier = 
             match assayArgs.TryGetFieldValue AssayRegisterArgs.StudyIdentifier with
@@ -183,7 +202,7 @@ module AssayAPI =
 
         s.RegisterAssay assayIdentifier
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
     
     /// Creates a new assay file and associated folder structure in the ARC and registers it in the ARC's investigation file with the given assay metadata contained in assayArgs.
@@ -209,8 +228,8 @@ module AssayAPI =
                 assayIdentifier
             | Some s -> s
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
 
         if isa.StudyIdentifiers |> Seq.contains studyIdentifier then
@@ -219,7 +238,7 @@ module AssayAPI =
         else
             log.Error($"Study with the identifier {studyIdentifier} does not exist.")
         
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
     
     /// Deletes an assay's folder and underlying file structure from the ARC.
@@ -277,13 +296,13 @@ module AssayAPI =
 
         let assayIdentifier = assayArgs.GetFieldValue AssayRemoveArgs.AssayIdentifier
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         isa.RegisteredStudies
         |> Seq.iter (fun s -> s.DeregisterAssay assayIdentifier)
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
         delete arcConfiguration (assayArgs.Cast<AssayDeleteArgs>())
@@ -300,8 +319,8 @@ module AssayAPI =
         let studyIdentifier = assayArgs.GetFieldValue AssayMoveArgs.StudyIdentifier
         let targetStudyIdentifer = assayArgs.GetFieldValue AssayMoveArgs.TargetStudyIdentifier
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         
         if isa.StudyIdentifiers |> Seq.contains studyIdentifier then
@@ -319,7 +338,7 @@ module AssayAPI =
 
                 targetStudy.RegisterAssay assayIdentifier
 
-                arc.ISA <- Some isa
+                arc <- isa
                 arc.Update(arcConfiguration)
 
             else 
@@ -340,7 +359,7 @@ module AssayAPI =
 
         let arc = ARC.load(arcConfiguration)
         let arcPath = GeneralConfiguration.getWorkDirectory arcConfiguration
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.AssayIdentifiers |> Seq.contains assayIdentifier then
             if isa.AssayIdentifiers |> Seq.contains newAssayIdentifier then
@@ -361,7 +380,7 @@ module AssayAPI =
         let assayIdentifier = assayArgs.GetFieldValue AssayShowArgs.AssayIdentifier
 
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         try 
             isa.GetAssay assayIdentifier 
@@ -380,7 +399,7 @@ module AssayAPI =
         log.Info("Start Assay List")
         
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         let studies = 
             isa.RegisteredStudies
@@ -410,7 +429,7 @@ module AssayAPI =
         let assayIdentifier = assayArgs.GetFieldValue AssayExportArgs.AssayIdentifier
         
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.ContainsAssay assayIdentifier then
             
@@ -442,7 +461,7 @@ module AssayAPI =
         log.Info("Start exporting all assays")
         
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.AssayCount > 0 then
             
@@ -523,7 +542,7 @@ module AssayAPI =
             let assayIdentifier = personArgs.GetFieldValue PersonUpdateArgs.AssayIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
 
             match isa.TryGetAssay(assayIdentifier) with
@@ -562,7 +581,7 @@ module AssayAPI =
             let assayIdentifier = personArgs.GetFieldValue PersonEditArgs.AssayIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetAssay(assayIdentifier) with
             | Some a ->
@@ -615,7 +634,7 @@ module AssayAPI =
             person.ORCID <- orcid
                        
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetAssay(assayIdentifier) with
             | Some a ->
@@ -644,7 +663,7 @@ module AssayAPI =
             let midInitials = personArgs.TryGetFieldValue PersonUnregisterArgs.MidInitials
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let tryGetIndex (persons : Person seq) =
                 persons
@@ -680,7 +699,7 @@ module AssayAPI =
             let midInitials = personArgs.TryGetFieldValue PersonShowArgs.MidInitials
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetAssay(assayIdentifier) with
             | Some a ->
@@ -704,7 +723,7 @@ module AssayAPI =
 
             let arc = ARC.load(arcConfiguration)
             
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             isa.Assays
             |> Seq.iter (fun a ->

--- a/src/ArcCommander/APIs/InvestigationAPI.fs
+++ b/src/ArcCommander/APIs/InvestigationAPI.fs
@@ -58,12 +58,12 @@ module InvestigationAPI =
                 ?publicReleaseDate = investigationArgs.TryGetFieldValue InvestigationUpdateArgs.PublicReleaseDate
             )
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier())) //(ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
 
         isa.UpdateTopLevelInfo(investigation, replaceWithEmptyValues)
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
     /// Opens the existing investigation info in the ARC with the text editor set in globalArgs.
@@ -75,8 +75,8 @@ module InvestigationAPI =
 
         let editor = GeneralConfiguration.getEditor arcConfiguration
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = Some arc |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         let editedInvestigation =
             ArgumentProcessing.Prompt.createIsaItemQuery editor ArcInvestigation.InvestigationInfo.toRows
@@ -85,7 +85,7 @@ module InvestigationAPI =
 
         isa.UpdateTopLevelInfo(editedInvestigation, true)
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
 
@@ -114,7 +114,7 @@ module InvestigationAPI =
         log.Info("Start Investigation Show")
 
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
         
         Prompt.serializeXSLXWriterOutput ArcInvestigation.InvestigationInfo.toRows isa
         |> log.Debug
@@ -188,7 +188,7 @@ module InvestigationAPI =
             person.ORCID <- orcid
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
            
             match Person.tryGetByFullName firstName (midInitials |> Option.defaultValue "") lastName (Array.ofSeq isa.Contacts) with
             | Some p ->
@@ -211,7 +211,7 @@ module InvestigationAPI =
             log.Info("Start Person Edit")
             let editor = GeneralConfiguration.getEditor arcConfiguration
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let lastName    = personArgs.GetFieldValue PersonEditArgs.LastName
             let firstName   = personArgs.GetFieldValue PersonEditArgs.FirstName
@@ -261,7 +261,7 @@ module InvestigationAPI =
             person.ORCID <- orcid
                        
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc)|> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             if Person.existsByFullName firstName (midInitials |> Option.defaultValue "") lastName (Array.ofSeq isa.Contacts) then
                 log.Error $"Person with the name {firstName} {midInitials} {lastName} does already exist in the investigation."
@@ -282,7 +282,7 @@ module InvestigationAPI =
             let midInitials = personArgs.TryGetFieldValue PersonUnregisterArgs.MidInitials
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let tryGetIndex (persons : Person seq) =
                 persons
@@ -312,7 +312,7 @@ module InvestigationAPI =
             let midInitials = personArgs.TryGetFieldValue PersonShowArgs.MidInitials
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match Person.tryGetByFullName firstName (midInitials |> Option.defaultValue "") lastName (Array.ofSeq isa.Contacts) with
             | Some person ->
@@ -330,7 +330,7 @@ module InvestigationAPI =
             log.Info("Start Person List")
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             isa.Contacts
             |> Seq.iter (
@@ -403,7 +403,7 @@ module InvestigationAPI =
                      (ResizeArray())
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match Publication.tryGetByDOI doi isa.Publications with
             | Some p ->
@@ -431,7 +431,7 @@ module InvestigationAPI =
             let doi = publicationArgs.GetFieldValue PublicationEditArgs.DOI
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match Publication.tryGetByDOI doi isa.Publications with
             | Some publication ->
@@ -468,7 +468,7 @@ module InvestigationAPI =
 
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             if Publication.existsByDOI doi isa.Publications then
                 log.Warn($"Publication with the doi {doi} already exists in the investigation.")
@@ -487,7 +487,7 @@ module InvestigationAPI =
             let doi = publicationArgs.GetFieldValue PublicationUnregisterArgs.DOI
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match Publication.tryFindIndexByDOI doi isa.Publications with
             | Some index ->
@@ -507,7 +507,7 @@ module InvestigationAPI =
             let doi = publicationArgs.GetFieldValue PublicationShowArgs.DOI
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match Publication.tryGetByDOI doi isa.Publications with
             | Some publication ->
@@ -525,7 +525,7 @@ module InvestigationAPI =
             log.Info("Start Publication List")
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.Publications with
             | publications when Seq.isEmpty publications ->

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -52,14 +52,14 @@ module StudyAPI =
                 ?publicReleaseDate = studyArgs.TryGetFieldValue StudyInitArgs.PublicReleaseDate
                 )
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.StudyIdentifiers |> Seq.contains identifier then
             log.Error($"Study with identifier {identifier} already exists.")
         
         isa.AddStudy(study)
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
     /// Updates an existing study info in the ARC with the given study metadata contained in cliArgs.
@@ -83,8 +83,8 @@ module StudyAPI =
                 ?publicReleaseDate = studyArgs.TryGetFieldValue StudyUpdateArgs.PublicReleaseDate
                 )
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         let msg = $"Study with the identifier {identifier} does not exist."
         match isa.TryGetStudy identifier with
@@ -99,7 +99,7 @@ module StudyAPI =
             log.Error($"{msg}")
             log.Trace("AddIfMissing argument can be used to register study with the update command if it is missing.")
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)        
 
     // /// Opens an existing study file in the ARC with the text editor set in globalArgs, additionally setting the given study metadata contained in cliArgs.
@@ -121,8 +121,8 @@ module StudyAPI =
                 (Studies.fromRows 1 >> fun (_,_,_,items) -> items.Value |> fst) 
                 oldStudy
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         match isa.TryGetStudy studyIdentifier with 
         | Some study ->
@@ -131,7 +131,7 @@ module StudyAPI =
         | None ->
             log.Error($"Study with the identifier {studyIdentifier} does not exist.")
 
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
     /// Registers an existing study in the ARC's investigation file with the given study metadata contained in cliArgs.
@@ -143,14 +143,14 @@ module StudyAPI =
 
         let identifier = studyArgs.GetFieldValue StudyRegisterArgs.StudyIdentifier
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.RegisteredStudyIdentifiers |> Seq.contains identifier then
             log.Error($"Study with identifier {identifier} is already registered.")
         else
         isa.RegisterStudy(identifier)
-        arc.ISA <- Some isa
+        arc <- isa
         arc.Update(arcConfiguration)
 
     /// Creates a new study file in the ARC and registers it in the ARC's investigation file with the given study metadata contained in cliArgs.
@@ -213,12 +213,12 @@ module StudyAPI =
 
         let identifier = studyArgs.GetFieldValue StudyUnregisterArgs.StudyIdentifier
 
-        let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let mutable arc = ARC.load(arcConfiguration)
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.RegisteredStudyIdentifiers |> Seq.contains identifier then
             isa.DeregisterStudy(identifier) |> ignore
-            arc.ISA <- Some isa
+            arc <- isa
             arc.Update(arcConfiguration)
         else
             log.Error($"Study with identifier {identifier} is not registered.")
@@ -240,7 +240,7 @@ module StudyAPI =
 
         let arc = ARC.load(arcConfiguration)
         let arcPath = GeneralConfiguration.getWorkDirectory arcConfiguration
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         if isa.StudyIdentifiers |> Seq.contains oldIdentifier then
             if isa.StudyIdentifiers |> Seq.contains newIdentifier then
@@ -260,7 +260,7 @@ module StudyAPI =
         let identifier = studyArgs.GetFieldValue StudyShowArgs.StudyIdentifier
 
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         match isa.TryGetStudy identifier with
         | Some study -> 
@@ -276,7 +276,7 @@ module StudyAPI =
         let log = Logging.createLogger "StudyListLog"
         
         let arc = ARC.load(arcConfiguration)
-        let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+        let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
         let registered = 
             isa.RegisteredStudyIdentifiers
@@ -334,7 +334,7 @@ module StudyAPI =
             let studyIdentifier = personArgs.GetFieldValue PersonUpdateArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -372,7 +372,7 @@ module StudyAPI =
             let studyIdentifier = personArgs.GetFieldValue PersonEditArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -425,7 +425,7 @@ module StudyAPI =
             person.ORCID <- orcid
                        
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -454,7 +454,7 @@ module StudyAPI =
             let midInitials = personArgs.TryGetFieldValue PersonUnregisterArgs.MidInitials
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let tryGetIndex (persons : Person seq) =
                 persons
@@ -490,7 +490,7 @@ module StudyAPI =
             let midInitials = personArgs.TryGetFieldValue PersonShowArgs.MidInitials
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -513,7 +513,7 @@ module StudyAPI =
             log.Info("Start Person List")
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             isa.Studies
             |> Seq.iter (fun a ->
@@ -560,7 +560,7 @@ module StudyAPI =
                      (ResizeArray())
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let studyIdentifier = publicationArgs.GetFieldValue PublicationUpdateArgs.StudyIdentifier
 
@@ -598,7 +598,7 @@ module StudyAPI =
             let studyIdentifier = publicationArgs.GetFieldValue PublicationEditArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -639,7 +639,7 @@ module StudyAPI =
                     (ResizeArray())
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let studyIdentifier = publicationArgs.GetFieldValue PublicationRegisterArgs.StudyIdentifier
 
@@ -667,7 +667,7 @@ module StudyAPI =
             let studyIdentifier = publicationArgs.GetFieldValue PublicationUnregisterArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -694,7 +694,7 @@ module StudyAPI =
             let studyIdentifier = publicationArgs.GetFieldValue PublicationShowArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy(studyIdentifier) with
             | Some s ->
@@ -716,7 +716,7 @@ module StudyAPI =
             log.Info("Start Publication List")
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             isa.Studies
             |> Seq.iter (fun study ->
@@ -781,7 +781,7 @@ module StudyAPI =
                     )
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             let studyIdentifier = designArgs.GetFieldValue DesignUpdateArgs.StudyIdentifier
 
@@ -818,8 +818,7 @@ module StudyAPI =
             let studyIdentifier = designArgs.GetFieldValue DesignEditArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
-
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
             
             match isa.TryGetStudy studyIdentifier with
             | Some s ->
@@ -855,7 +854,7 @@ module StudyAPI =
                     )
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy studyIdentifier with
             | Some s ->
@@ -879,7 +878,7 @@ module StudyAPI =
             let studyIdentifier = designArgs.GetFieldValue DesignUnregisterArgs.StudyIdentifier
 
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy studyIdentifier with
             | Some s ->
@@ -900,7 +899,7 @@ module StudyAPI =
             let name = designArgs.GetFieldValue DesignShowArgs.DesignType
             let studyIdentifier = designArgs.GetFieldValue DesignShowArgs.StudyIdentifier
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             match isa.TryGetStudy studyIdentifier with
             | Some s ->
@@ -922,7 +921,7 @@ module StudyAPI =
             
             log.Info("Start Design List")
             let arc = ARC.load(arcConfiguration)
-            let isa = arc.ISA |> Option.defaultValue (ArcInvestigation(Helper.Identifier.createMissingIdentifier()))
+            let isa = (Some arc) |> Option.defaultValue (ARC(Helper.Identifier.createMissingIdentifier()))
 
             isa.Studies
             |> Seq.iter (fun study ->

--- a/src/ArcCommander/APIs/StudyAPI.fs
+++ b/src/ArcCommander/APIs/StudyAPI.fs
@@ -1197,7 +1197,7 @@ module StudyAPI =
     //        | None -> 
     //            log.Error("The investigation does not contain any studies.")
 
-    /// Functions for altering investigation protocols.
+    // Functions for altering investigation protocols.
     //module Protocols =
         
     //    open CLIArguments.StudyProtocols

--- a/src/ArcCommander/ArcCommander.fsproj
+++ b/src/ArcCommander/ArcCommander.fsproj
@@ -70,16 +70,16 @@
 
   <!--References-->
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.101" />
-    <PackageReference Include="ARCtrl" Version="2.5.1" />
-    <PackageReference Include="Argu" Version="6.1.5" />
-    <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
-    <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
-    <PackageReference Include="FSharp.Data" Version="5.0.2" />
+    <PackageReference Update="FSharp.Core" Version="10.0.101" />
+    <PackageReference Include="ARCtrl" Version="3.1.0" />
+    <PackageReference Include="Argu" Version="6.2.5" />
+    <PackageReference Include="Fake.IO.FileSystem" Version="6.1.4" />
+    <PackageReference Include="Fake.Tools.Git" Version="6.1.4" />
+    <PackageReference Include="FSharp.Data" Version="8.1.14" />
     <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
-    <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
-    <PackageReference Include="Giraffe" Version="6.0.0" />
-    <PackageReference Include="NLog" Version="5.4.0" />
-    <PackageReference Include="Octokit" Version="5.0.0" />
+    <PackageReference Include="ini-parser-netstandard" Version="2.5.3" />
+    <PackageReference Include="Giraffe" Version="8.2.0" />
+    <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 </Project>

--- a/src/ArcCommander/ArcConfiguration.fs
+++ b/src/ArcCommander/ArcConfiguration.fs
@@ -440,7 +440,7 @@ module ARCExtensions =
         if System.IO.File.Exists path then 
             ()
         else 
-            Contract.fulfillWriteContractAsync basePath c
+            Contract.fulfillWriteContractAsync false basePath c //false means do not override existing files
             |> Async.RunSynchronously
             |> ignore
 

--- a/src/ArcCommander/Program.fs
+++ b/src/ArcCommander/Program.fs
@@ -1,4 +1,4 @@
-﻿module ArcCommander.Program
+﻿module ArcCommander.Program 
 
 // Learn more about F# at http://fsharp.org
 open ArcCommander
@@ -162,16 +162,18 @@ let handleStudySubCommands arcConfiguration studyVerb =
     | StudyCommand.Init r                   -> processCommand arcConfiguration StudyAPI.init        r
     | StudyCommand.Register r               -> processCommand arcConfiguration StudyAPI.register    r
     | StudyCommand.Add r                    -> processCommand arcConfiguration StudyAPI.add         r
+    | StudyCommand.Delete r                 -> processCommand arcConfiguration StudyAPI.delete      r    
+    | StudyCommand.Unregister r             -> processCommand arcConfiguration StudyAPI.unregister  r    
     | StudyCommand.Remove r                 -> processCommand arcConfiguration StudyAPI.remove      r
-    | StudyCommand.Unregister r             -> processCommand arcConfiguration StudyAPI.unregister  r
-    | StudyCommand.Delete r                 -> processCommand arcConfiguration StudyAPI.delete      r
     | StudyCommand.Update r                 -> processCommand arcConfiguration StudyAPI.update      r
     | StudyCommand.Edit r                   -> processCommand arcConfiguration StudyAPI.edit        r
+    | StudyCommand.Rename r                 -> processCommand arcConfiguration StudyAPI.rename      r
     | StudyCommand.Show r                   -> processCommand arcConfiguration StudyAPI.show        r
     | StudyCommand.List                     -> processCommandWithoutArgs arcConfiguration StudyAPI.list
     | StudyCommand.Person subCommand        -> handleStudyContactsSubCommands arcConfiguration (subCommand.GetSubCommand())
     | StudyCommand.Publication subCommand   -> handleStudyPublicationsSubCommands arcConfiguration (subCommand.GetSubCommand())
     | StudyCommand.Design subCommand        -> handleStudyDesignSubCommands arcConfiguration (subCommand.GetSubCommand())
+
     //| StudyCommand.Factor subCommand        -> handleStudyFactorSubCommands arcConfiguration (subCommand.GetSubCommand())
     //| StudyCommand.Protocol subCommand      -> handleStudyProtocolSubCommands arcConfiguration (subCommand.GetSubCommand())
 
@@ -186,9 +188,10 @@ let handleAssaySubCommands arcConfiguration assayVerb =
     | AssayCommand.Update             r -> processCommand arcConfiguration AssayAPI.update        r
     | AssayCommand.Edit               r -> processCommand arcConfiguration AssayAPI.edit          r
     | AssayCommand.Move               r -> processCommand arcConfiguration AssayAPI.move          r
+    | AssayCommand.Rename             r -> processCommand arcConfiguration AssayAPI.rename r
     | AssayCommand.Show               r -> processCommand arcConfiguration AssayAPI.show          r
+    | AssayCommand.List                 -> processCommandWithoutArgs arcConfiguration AssayAPI.list    
     | AssayCommand.Export             r -> processCommand arcConfiguration AssayAPI.export        r
-    | AssayCommand.List                 -> processCommandWithoutArgs arcConfiguration AssayAPI.list
     | AssayCommand.Person subCommand    -> handleAssayContactsSubCommands arcConfiguration (subCommand.GetSubCommand())
 
 let handleConfigurationSubCommands arcConfiguration configurationVerb =

--- a/src/ArcCommander/Server/ArcAPIHandler.fs
+++ b/src/ArcCommander/Server/ArcAPIHandler.fs
@@ -65,7 +65,7 @@ let arcImportHandler : HttpHandler =
 
             ArcInvestigation.fromJsonString isaJsonString
             //|> fun i -> {i with Remarks = []}
-            |> fun i -> ARC(i).Write(tmpDir)
+            |> fun i -> ARC(i.Identifier).Write(tmpDir)
 
             System.IO.Compression.ZipFile.CreateFromDirectory(tmpDir,tmpZip )
 

--- a/tests/ArcCommander.Tests/ArcCommander.Tests.fsproj
+++ b/tests/ArcCommander.Tests/ArcCommander.Tests.fsproj
@@ -19,12 +19,12 @@
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AltCover" Version="7.1.778" />
-    <PackageReference Include="Expecto" Version="10.2.3" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
-    <PackageReference Update="FSharp.Core" Version="8.0.101" />
-    <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
+    <PackageReference Update="FSharp.Core" Version="10.0.101" />
+    <PackageReference Include="AltCover" Version="9.0.102" />
+    <PackageReference Include="Expecto" Version="10.*" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.14.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="ini-parser-netstandard" Version="2.5.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TestFiles\" />

--- a/tests/ArcCommander.Tests/ArcTests.fs
+++ b/tests/ArcCommander.Tests/ArcTests.fs
@@ -18,6 +18,7 @@ let testArcInit =
     testList testListName [
         testCase "Simple" (fun () -> 
             let config = createConfigFromDir testListName "Simple"
+            resetArc config
             let identifier = "MyInvestigation"
             let investigationArgs = [ArcInitArgs.InvestigationIdentifier identifier]
 
@@ -31,6 +32,7 @@ let testArcInit =
         testCase "NoIdentifierGiven" (fun () -> 
             let workdirName = "NoIdentifierGiven"
             let config = createConfigFromDir testListName workdirName
+            resetArc config
             let investigationArgs : ArcInitArgs list = []
 
             processCommand config ArcAPI.init investigationArgs
@@ -42,6 +44,7 @@ let testArcInit =
         )
         testCase "ShouldNotOverwrite" (fun () -> 
             let config = createConfigFromDir testListName "Simple"
+            resetArc config
             let identifier = "MyInvestigation"
             let investigationArgs = [ArcInitArgs.InvestigationIdentifier identifier]
 
@@ -58,6 +61,7 @@ let testArcInit =
         )
         testCase "CreateGitIgnore" (fun () ->
             let config = createConfigFromDir testListName "CreateGitIgnore"
+            setupArc config
             let investigationArgs = [ArcInitArgs.Gitignore]
         
             processCommand config ArcAPI.init investigationArgs
@@ -75,6 +79,7 @@ let testArcUpdate =
     testList testListName [
         testCase "DontPutAssayPerformerIntoStudy" (fun () -> 
             let config = createConfigFromDir testListName "DontPutAssayPerformerIntoStudy"
+            setupArc config
 
             let identifier = "MyInvestigation"
             let investigationArgs = [ArcInitArgs.InvestigationIdentifier identifier]
@@ -109,6 +114,7 @@ let testArcExport =
     testList testListName [
         testCase "Simple" (fun () -> 
             let config = createConfigFromDir testListName "Simple"
+            resetArc config
 
             let identifier = "MyInvestigation"
             let investigationArgs = [ArcInitArgs.InvestigationIdentifier identifier]
@@ -132,8 +138,9 @@ let testArcExport =
             Expect.sequenceEqual study.RegisteredAssayIdentifiers [assayIdentifier] "Assay was not exported"
 
         )
-        ptestCase "OnlyExportRegistered" (fun () ->
+        testCase "ExportsStudiesAndRegisteredAssays" (fun () -> // is ptestCase
             let config = createConfigFromDir testListName "OnlyExportRegistered"
+            resetArc config
 
             let identifier = "MyInvestigation"
             let investigationArgs = [ArcInitArgs.InvestigationIdentifier identifier]
@@ -160,7 +167,7 @@ let testArcExport =
             let isa = ArcInvestigation.fromISAJsonString (System.IO.File.ReadAllText exportPath)
 
             Expect.equal isa.Identifier identifier "Identifier was not set correctly in exported json"
-            Expect.equal isa.Studies.Count 1 "Only one study should be exported"
+            Expect.equal isa.Studies.Count 2 "Both studies should be exported"
             let study = Expect.wantSome (isa.TryGetStudy registeredAssayIdentifier) "Study was not exported"
 
             Expect.equal isa.AssayCount 1 "Only one assay should be exported"

--- a/tests/ArcCommander.Tests/ArcTests.fs
+++ b/tests/ArcCommander.Tests/ArcTests.fs
@@ -24,7 +24,7 @@ let testArcInit =
             processCommand config ArcAPI.init investigationArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc) "ISA was not created"
 
             Expect.equal isa.Identifier identifier "Identifier was not set correctly"
         )
@@ -36,7 +36,7 @@ let testArcInit =
             processCommand config ArcAPI.init investigationArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc) "ISA was not created"
 
             Expect.equal isa.Identifier workdirName "Identifier was not set correctly"
         )
@@ -52,7 +52,7 @@ let testArcInit =
             processCommand config ArcAPI.init secondInvestigationArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc) "ISA was not created"
 
             Expect.equal isa.Identifier identifier "Identifier was overwritten"
         )
@@ -92,7 +92,7 @@ let testArcUpdate =
             processCommand config AssayAPI.Contacts.register personArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc) "ISA was not created"
             let study = Expect.wantSome (isa.TryGetStudy assayIdentifier) "Study was not created"
             Expect.equal study.Contacts.Count 0 "Study should not have any contacts"
             let assay = Expect.wantSome (study.TryGetRegisteredAssay assayIdentifier) "Assay was not created"

--- a/tests/ArcCommander.Tests/AssayTests.fs
+++ b/tests/ArcCommander.Tests/AssayTests.fs
@@ -12,9 +12,12 @@ open ArcCommander.CLIArguments
 open ArcCommander.APIs
 
 let setupArc (arcConfiguration : ArcConfiguration) =
+    let testDir = arcConfiguration.General.["workdir"]
+    if System.IO.Directory.Exists(testDir) then
+        System.IO.Directory.Delete(testDir, true)
+    
     let arcArgs : ArcInitArgs list = [ArcInitArgs.InvestigationIdentifier "TestInvestigation"] 
-
-    processCommand arcConfiguration ArcAPI.init             arcArgs
+    processCommand arcConfiguration ArcAPI.init arcArgs
 
 let testAssayTestFunction = 
 
@@ -359,7 +362,7 @@ let testAssayUpdate =
             let configuration = createConfigFromDir "AssayUpdateTests" "UpdateStandard"
             setupArc configuration
             let studyIdentifier = "Study1"
-            let assayIdentifier = "Assay2"
+            let assayIdentifier = "Assay2" 
 
             let assay1Args = [
                 AssayAddArgs.StudyIdentifier studyIdentifier
@@ -395,24 +398,32 @@ let testAssayUpdate =
             let arcBeforeUpdate = ARC.load(configuration)
             let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
-
             processCommand configuration AssayAPI.update assayUpdateArgs
             
             let arc = ARC.load(configuration)
             let isa = Expect.wantSome (Some arc)"Investigation was not created"
             
-            Expect.equal (isa.GetStudyAt(1).RegisteredAssays[0]) (isaBeforeUpdate.GetStudyAt(1).RegisteredAssays[0]) "Only assay in first study was supposed to be updated, but study 2 is also different"
-            
-            let study = isa.GetStudyAt 0
-            let studyBeforeUpdate = isaBeforeUpdate.GetStudyAt 0
+            let study2 = isa.GetStudy "Study2"
+            let study2BeforeUpdate = isaBeforeUpdate.GetStudy "Study2"
 
-            Expect.equal (study.RegisteredAssays[0]) (studyBeforeUpdate.RegisteredAssays[0]) "Only assay number 1 in first study was supposed to be updated, but first assay is also different"
+            Expect.equal
+                (study2.GetRegisteredAssay "Assay3")
+                (study2BeforeUpdate.GetRegisteredAssay "Assay3")
+                "Study2 should not have changed"
 
-            let assay = study.RegisteredAssays[1]
+            let study1 = isa.GetStudy "Study1"
+            let study1BeforeUpdate = isaBeforeUpdate.GetStudy "Study1"
 
-            Expect.equal assay.Identifier testAssay.Identifier "Assay Filename has changed even though it shouldn't"
-            Expect.equal assay.TechnologyType testAssay.TechnologyType "Assay technology type has changed, even though no value was given and the \"ReplaceWithEmptyValues\" flag was not set"
-            Expect.equal assay.MeasurementType testAssay.MeasurementType "Assay Measurement type was not updated correctly"
+            Expect.equal
+                (study1.GetRegisteredAssay "Assay1")
+                (study1BeforeUpdate.GetRegisteredAssay "Assay1")
+                "Assay1 should not have changed"
+
+            let assay = study1.GetRegisteredAssay assayIdentifier
+
+            Expect.equal assay.Identifier testAssay.Identifier "Assay identifier changed"
+            Expect.equal assay.TechnologyType testAssay.TechnologyType "Technology type changed unexpectedly"
+            Expect.equal assay.MeasurementType testAssay.MeasurementType "Measurement type was not updated correctly"
 
         )
         testCase "UpdateReplaceWithEmpty" (fun () -> 
@@ -672,17 +683,22 @@ let testAssayMove =
             let arc = ARC.load(configuration)
             let isa = Expect.wantSome (Some arc)"Investigation was not created"  
 
-            Expect.isNone (isa.GetStudyAt(0).TryGetRegisteredAssay assayIdentifier) "Assay was not removed from source study"
+            let sourceStudy = isa.GetStudy studyIdentifier
 
-            let study = isa.TryGetStudy "NewStudy"
+            Expect.isNone
+                (sourceStudy.TryGetRegisteredAssay assayIdentifier)
+                "Assay was not removed from source study"
 
-            Expect.isSome study "New Study was not created"
+            let targetStudy =
+                isa
+                |> fun investigation -> investigation.TryGetStudy targetStudyIdentfier
 
-            let assay = study.Value.TryGetRegisteredAssay assayIdentifier
+            let targetStudy =
+                Expect.wantSome targetStudy "New Study was not created"
 
-            Expect.isSome assay "Assay was not added to target study"
+            let assay = targetStudy.GetRegisteredAssay assayIdentifier
 
-            Expect.equal assay.Value testAssay "Assay was moved but some values are not correct"
+            Expect.equal assay testAssay "Assay was not added to the new study correctly"
             
         )
         testCase "AssayDoesNotExist" (fun () -> 

--- a/tests/ArcCommander.Tests/AssayTests.fs
+++ b/tests/ArcCommander.Tests/AssayTests.fs
@@ -27,14 +27,14 @@ let testAssayTestFunction =
             let tt = OntologyAnnotation("mass spectrometry","OBI")
             let tp = OntologyAnnotation "iTRAQ"
 
-            let testAssay = ArcAssay.create(assayIdentifier,mt,tt,tp)
+            let testAssay = ArcAssay.create(identifier = assayIdentifier, measurementType = mt, technologyType = tt, technologyPlatform = tp)
 
             let arc = ARC.load(testDirectory)
-            let investigation = arc.ISA.Value
+            //let investigation = arc.ISA.Value
             // Positive control
-            Expect.equal investigation.Studies.[0].RegisteredAssays.[0] testAssay "The assay in the file should match the one created per hand but did not"
+            Expect.equal arc.Studies.[0].RegisteredAssays.[0] testAssay "The assay in the file should match the one created per hand but did not"
             // Negative control
-            Expect.notEqual investigation.Studies.[0].RegisteredAssays.[1] testAssay "The assay in the file did not match the one created per hand and still returned true"
+            Expect.notEqual arc.Studies.[0].RegisteredAssays.[1] testAssay "The assay in the file did not match the one created per hand and still returned true"
         )
         testCase "ListsCorrectAssaysInCorrectStudies" (fun () -> 
             let testAssays = [
@@ -43,11 +43,11 @@ let testAssayTestFunction =
             ]
 
             let arc = ARC.load(testDirectory)
-            let investigation = arc.ISA.Value
+            //let investigation = arc.ISA.Value
 
             testAssays
             |> List.iter (fun (studyIdentifier,assayIdentifiers) ->
-                match investigation.TryGetStudy studyIdentifier with
+                match arc.TryGetStudy studyIdentifier with
                 | Some study ->
                     Expect.sequenceEqual study.RegisteredAssayIdentifiers assayIdentifiers "Assay Filenames did not match the expected ones"
                 | None -> failwith "Study %s could not be taken from the ivnestigation even though it should be there"                    
@@ -88,7 +88,7 @@ let testAssayRegister =
             processCommand configuration AssayAPI.register assayRegisterArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             match isa.TryGetStudy studyIdentifier with
             | Some study ->
@@ -127,7 +127,7 @@ let testAssayRegister =
             Expect.throws (fun () -> processCommand configuration AssayAPI.add assay2Args) "trying to create a second, nearly identical assay which shall NOT work"
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             match isa.TryGetStudy studyIdentifier with
             | Some study ->
@@ -177,7 +177,7 @@ let testAssayRegister =
             processCommand configuration AssayAPI.register  assayRegisterArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             match isa.TryGetStudy studyIdentifier with
             | Some study ->
@@ -208,7 +208,7 @@ let testAssayRegister =
             processCommand configuration AssayAPI.add assayArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             let studyOption = isa.TryGetStudy studyIdentifier
             Expect.isSome studyOption "Study should have been created in order for assay to be placed in it"     
@@ -234,7 +234,7 @@ let testAssayRegister =
             processCommand configuration AssayAPI.add assayArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             let studyOption = isa.TryGetStudy assayIdentifier
             Expect.isSome studyOption "Study should have been created with the name of the assay but was not"     
@@ -257,7 +257,7 @@ let testAssayRegister =
             let testAssay = ArcAssay.create (assayIdentifier)
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
             
             let studiesWithIdentifiers = isa.StudyIdentifiers |> Seq.toList |> List.filter ((=) assayIdentifier)
             
@@ -282,7 +282,7 @@ let testAssayRegister =
             Expect.throws (fun () -> processCommand configuration AssayAPI.add assayArgs)  "trying to create a second, nearly identical assay which shall NOT work"
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
             
             let studiesWithIdentifiers = isa.StudyIdentifiers |> Seq.toList |> List.filter ((=) assayIdentifier)
             
@@ -341,7 +341,7 @@ let testAssayRemove =
             processCommand config AssayAPI.remove assayRemoveArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa.AssayCount 0 "Assay was not deleted"
             let study = Expect.wantSome (isa.TryGetStudy studyIdentifier) "Study was removed from the investigation"
@@ -385,7 +385,7 @@ let testAssayUpdate =
             let measurementType = "NewMeasurementType"
             let mt = OntologyAnnotation(measurementType)
             let tt = OntologyAnnotation("Assay2Tech")
-            let testAssay = ArcAssay.create(assayIdentifier,mt,tt)
+            let testAssay = ArcAssay.create(identifier = assayIdentifier, measurementType = mt, technologyType = tt)
 
             let assayUpdateArgs : AssayUpdateArgs list = [
                 AssayUpdateArgs.AssayIdentifier assayIdentifier
@@ -393,13 +393,13 @@ let testAssayUpdate =
             ]
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
 
             processCommand configuration AssayAPI.update assayUpdateArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
             
             Expect.equal (isa.GetStudyAt(1).RegisteredAssays[0]) (isaBeforeUpdate.GetStudyAt(1).RegisteredAssays[0]) "Only assay in first study was supposed to be updated, but study 2 is also different"
             
@@ -444,7 +444,7 @@ let testAssayUpdate =
 
             let newMeasurementType = "NewMeasurementType"
             let mt = OntologyAnnotation(newMeasurementType)
-            let testAssay = ArcAssay.create(assayIdentifier2,mt)
+            let testAssay = ArcAssay.create(identifier = assayIdentifier2, measurementType = mt)
 
             let assayUpdateArgs : AssayUpdateArgs list = [
                 AssayUpdateArgs.ReplaceWithEmptyValues
@@ -453,12 +453,12 @@ let testAssayUpdate =
             ]           
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             processCommand configuration AssayAPI.update assayUpdateArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"          
+            let isa = Expect.wantSome (Some arc) "Investigation was not created"          
 
             Expect.equal (isa.GetStudyAt(0)) (isaBeforeUpdate.GetStudyAt(0))  "Only assay in second study was supposed to be updated, but study 1 is also different"
             
@@ -512,12 +512,12 @@ let testAssayUnregister =
             processCommand configuration AssayAPI.add assay3Args
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             processCommand configuration AssayAPI.unregister assayArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"              
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"              
 
             Expect.equal (isa.RegisteredStudies[1]) (isaBeforeUpdate.RegisteredStudies[1])  "Only assay in first study was supposed to be unregistered, but study 2 is also different"
             
@@ -539,12 +539,12 @@ let testAssayUnregister =
             let assayArgs : AssayUnregisterArgs list = [AssayUnregisterArgs.StudyIdentifier studyIdentifier;AssayUnregisterArgs.AssayIdentifier assayIdentifier]
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             processCommand configuration AssayAPI.unregister assayArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"           
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"           
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given assay does not exist and none should have been removed"
             
@@ -563,12 +563,12 @@ let testAssayUnregister =
             ]
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             processCommand configuration AssayAPI.unregister assayUnrArgs
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"              
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"              
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given study does not exist and none should have been removed"
             
@@ -619,14 +619,14 @@ let testAssayMove =
 
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate)"Investigation was not created"
             let testAssay = isaBeforeUpdate.GetStudyAt(0).RegisteredAssays[1]
 
             processCommand configuration AssayAPI.move assayMovArgs
 
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"  
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"  
 
             Expect.equal (isa.GetStudyAt(0).RegisteredAssayCount) (isaBeforeUpdate.GetStudyAt(0).RegisteredAssayCount - 1) "Assay was not removed from source study"
 
@@ -663,14 +663,14 @@ let testAssayMove =
 
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
             let testAssay = isaBeforeUpdate.GetStudyAt(0).RegisteredAssays[0]
 
             processCommand configuration AssayAPI.move assayMovArgs
 
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"  
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"  
 
             Expect.isNone (isa.GetStudyAt(0).TryGetRegisteredAssay assayIdentifier) "Assay was not removed from source study"
 
@@ -698,13 +698,13 @@ let testAssayMove =
 
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate)"Investigation was not created"
 
             processCommand configuration AssayAPI.move assayArgs
 
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"           
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"           
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given assay does not exist and none should have been moved"
             
@@ -739,7 +739,7 @@ let testAssayRename =
             processCommand configuration AssayAPI.rename assayRenameArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc) "Investigation was not created"
 
             Expect.equal isa.AssayCount 1 "Assay count is incorrect after renaming assay"
 
@@ -772,7 +772,7 @@ let testAssayRename =
             processCommand configuration AssayAPI.init assayInitArgs2
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             Expect.equal isaBeforeUpdate.AssayCount 2 "Assay count is incorrect before renaming assay"
 
@@ -784,7 +784,7 @@ let testAssayRename =
             processCommand configuration AssayAPI.rename assayRenameArgs          
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the target assay identifier already exists and no renaming should have happened"
         )
@@ -802,12 +802,12 @@ let testAssayRename =
             ]
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             processCommand configuration AssayAPI.rename assayArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given assay does not exist and none should have been renamed"
                     
@@ -846,7 +846,7 @@ let testAssayPerformers =
             processCommand configuration AssayAPI.Contacts.register personRegisterArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             let assay = isa.GetAssay assayIdentifier
             Expect.equal assay.Performers.Count 1 "Person was not added to assay"
@@ -892,7 +892,7 @@ let testAssayPerformers =
             processCommand configuration AssayAPI.Contacts.register secondPersonRegisterArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             let assay = isa.GetAssay assayIdentifier
             Expect.equal assay.Performers.Count 2 "Person was not added to assay"
@@ -940,7 +940,7 @@ let testAssayPerformers =
 
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             let assay = isa.GetAssay assayIdentifier
             Expect.equal assay.Performers.Count 2 "Identical person was added to assay"
@@ -1000,7 +1000,7 @@ let testAssayPerformers =
             processCommand configuration AssayAPI.Contacts.update secondPersonUpdateArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             let assay = isa.GetAssay assayIdentifier
             Expect.equal assay.Performers.Count 2 "Identical person was added to assay"

--- a/tests/ArcCommander.Tests/AssayTests.fs
+++ b/tests/ArcCommander.Tests/AssayTests.fs
@@ -11,13 +11,6 @@ open ArgumentProcessing
 open ArcCommander.CLIArguments
 open ArcCommander.APIs
 
-let setupArc (arcConfiguration : ArcConfiguration) =
-    let testDir = arcConfiguration.General.["workdir"]
-    if System.IO.Directory.Exists(testDir) then
-        System.IO.Directory.Delete(testDir, true)
-    
-    let arcArgs : ArcInitArgs list = [ArcInitArgs.InvestigationIdentifier "TestInvestigation"] 
-    processCommand arcConfiguration ArcAPI.init arcArgs
 
 let testAssayTestFunction = 
 

--- a/tests/ArcCommander.Tests/AssayTests.fs
+++ b/tests/ArcCommander.Tests/AssayTests.fs
@@ -631,19 +631,24 @@ let testAssayMove =
 
             let arcBeforeUpdate = ARC.load(configuration)
             let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate)"Investigation was not created"
-            let testAssay = isaBeforeUpdate.GetStudyAt(0).RegisteredAssays[1]
+            let sourceStudyBeforeUpdate = isaBeforeUpdate.GetStudy studyIdentifier
+            let testAssay = sourceStudyBeforeUpdate.GetRegisteredAssay assayIdentifier
 
             processCommand configuration AssayAPI.move assayMovArgs
 
-            
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome (Some arc)"Investigation was not created"  
+            let isa =
+                Expect.wantSome (Some arc) "Investigation was not created"
 
-            Expect.equal (isa.GetStudyAt(0).RegisteredAssayCount) (isaBeforeUpdate.GetStudyAt(0).RegisteredAssayCount - 1) "Assay was not removed from source study"
+            let sourceStudy = isa.GetStudy studyIdentifier
+            let targetStudy = isa.GetStudy targetStudyIdentfier
 
-            let assay = isa.GetStudyAt(1).GetRegisteredAssay assayIdentifier
+            Expect.equal
+                sourceStudy.RegisteredAssayCount
+                (sourceStudyBeforeUpdate.RegisteredAssayCount - 1)
+                "Assay was not removed from source study"
 
-            //Expect.isSome assay "Assay was not added to target study"
+            let assay = targetStudy.GetRegisteredAssay assayIdentifier
 
             Expect.equal assay testAssay "Assay was moved but some values are not correct"
             

--- a/tests/ArcCommander.Tests/InvestigationTests.fs
+++ b/tests/ArcCommander.Tests/InvestigationTests.fs
@@ -38,7 +38,7 @@ let testInvestigationUpdate =
             processCommand config InvestigationAPI.update investigationArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc)"ISA was not created"
 
             Expect.equal isa.Identifier newIdentifier "Identifier was not set correctly"
 
@@ -69,7 +69,7 @@ let testInvestigationUpdate =
             processCommand config InvestigationAPI.update investigationArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc)"ISA was not created"
 
             Expect.equal isa.Identifier newIdentifier "Identifier should not be overwritten by empty identifier, even if \"overwrite by empty\" is set."
 
@@ -105,7 +105,7 @@ let testInvestigationContacts =
             processCommand configuration InvestigationAPI.Contacts.register personRegisterArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa.Contacts.Count 1 "Person was not added to assay"
             Expect.equal isa.Contacts.[0] testPerson "Person was not correctly added to assay"
@@ -141,7 +141,7 @@ let testInvestigationContacts =
             processCommand configuration InvestigationAPI.Contacts.register secondPersonRegisterArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa.Contacts.Count 2 "Person was not added to assay"
             Expect.equal isa.Contacts.[1] testPerson "Person was not correctly added to assay"       
@@ -179,7 +179,7 @@ let testInvestigationContacts =
 
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc) "Investigation was not created"
 
             Expect.equal isa.Contacts.Count 2 "Identical person was added to assay"
             Expect.equal isa.Contacts.[1] testPerson "Person was modified"       
@@ -228,7 +228,7 @@ let testInvestigationContacts =
             processCommand configuration InvestigationAPI.Contacts.update secondPersonUpdateArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa.Contacts.Count 2 "Identical person was added to assay"
             Expect.equal isa.Contacts.[0] testPerson1 "Person was modified"       

--- a/tests/ArcCommander.Tests/StudyTests.fs
+++ b/tests/ArcCommander.Tests/StudyTests.fs
@@ -10,11 +10,6 @@ open ArgumentProcessing
 open ArcCommander.CLIArguments
 open ArcCommander.APIs
 
-let setupArc (arcConfiguration:ArcConfiguration) =
-    let arcArgs : ArcInitArgs list =  [ArcInitArgs.InvestigationIdentifier "TestInvestigation"] 
-
-    processCommand arcConfiguration ArcAPI.init             arcArgs
-
 let testStudyInit = 
     
     let testListName = "StudyInitTests"

--- a/tests/ArcCommander.Tests/StudyTests.fs
+++ b/tests/ArcCommander.Tests/StudyTests.fs
@@ -30,7 +30,7 @@ let testStudyInit =
             processCommand config StudyAPI.init studyArgs
 
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc) "ISA was not created"
             Expect.equal isa.Studies.Count 1 "Study was not initialized in ARC"
             Expect.equal isa.RegisteredStudies.Count 0 "Study was registered to ISA, even though it should not have been"   
         )
@@ -56,7 +56,7 @@ let testStudyAdd =
             let studyArgs = [StudyAddArgs.StudyIdentifier studyIdentifier;StudyAddArgs.Description studyDescription]
             processCommand config StudyAPI.add studyArgs
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created" 
+            let isa = Expect.wantSome (Some arc)"ISA was not created" 
             Expect.equal isa.Studies.Count 1 "Study was not initialized in ARC"
             Expect.equal isa.RegisteredStudies.Count 1 "Study was not registetered to ISA"
             Expect.equal isa.RegisteredStudies.[0].Identifier studyIdentifier "Study was not registetered to ISA with correct identifier"
@@ -81,7 +81,7 @@ let testStudyAdd =
             let studyArgs = [StudyAddArgs.StudyIdentifier studyIdentifier;StudyAddArgs.Description studyDescription]
             processCommand config StudyAPI.add studyArgs
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc)"ISA was not created"
             Expect.equal isa.Studies.Count 2 "Second study was not added to ISA"
             Expect.equal isa.RegisteredStudies.Count 2 "Second study was not registetered to ISA"
             Expect.equal isa.RegisteredStudies.[1].Identifier studyIdentifier "Second study was not registetered to ISA with correct identifier"
@@ -112,7 +112,7 @@ let testStudyAdd =
             let studyArgs = [StudyAddArgs.StudyIdentifier studyIdentifier;StudyAddArgs.Description studyDescription]
             Expect.throws (fun () -> processCommand config StudyAPI.add studyArgs) "Study was added to ISA, even though it already existed"
             let arc = ARC.load(config)
-            let isa = Expect.wantSome arc.ISA "ISA was not created"
+            let isa = Expect.wantSome (Some arc)"ISA was not created"
             Expect.equal isa.Studies.Count 2 "Second study was added to ISA, even though it already existed"
             Expect.equal isa.RegisteredStudies.Count 2 "Second study was added to ISA, even though it already existed"
         )
@@ -268,7 +268,7 @@ let testStudyRename =
             processCommand configuration StudyAPI.rename studyRenameArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc) "Investigation was not created"
 
             Expect.equal isa.StudyCount 1 "Study count is incorrect after renaming study"
 
@@ -301,7 +301,7 @@ let testStudyRename =
             processCommand configuration StudyAPI.init studyInitArgs2
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate) "Investigation was not created"
 
             Expect.equal isaBeforeUpdate.StudyCount 2 "Study count is incorrect before renaming study"
 
@@ -313,7 +313,7 @@ let testStudyRename =
             processCommand configuration StudyAPI.rename studyRenameArgs          
             
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc)"Investigation was not created"
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the target study identifier already exists and no renaming should have happened"
         )
@@ -331,12 +331,12 @@ let testStudyRename =
             ]
 
             let arcBeforeUpdate = ARC.load(configuration)
-            let isaBeforeUpdate = Expect.wantSome arcBeforeUpdate.ISA "Investigation was not created"
+            let isaBeforeUpdate = Expect.wantSome (Some arcBeforeUpdate)"Investigation was not created"
 
             processCommand configuration StudyAPI.rename studyArgs
 
             let arc = ARC.load(configuration)
-            let isa = Expect.wantSome arc.ISA "Investigation was not created"
+            let isa = Expect.wantSome (Some arc) "Investigation was not created"
 
             Expect.equal isa isaBeforeUpdate "Investigation values did change even though the given study does not exist and none should have been renamed"
                     
@@ -370,7 +370,7 @@ let testStudyContacts =
     let arc = ARC.load(config)
 
     let studyBeforeChangingIt = 
-        arc.ISA.Value.GetStudy studyIdentifier
+        arc.GetStudy studyIdentifier
 
     testList testListName [
         testCase "Update" (fun () -> 
@@ -401,9 +401,9 @@ let testStudyContacts =
             processCommand config StudyAPI.Contacts.update contactArgs
             
             let arc = ARC.load(config)
-            let investigation = arc.ISA.Value
+            // let investigation = arc.ISA.Value
 
-            let study = investigation.TryGetStudy studyIdentifier
+            let study = arc.TryGetStudy studyIdentifier
 
             Expect.isSome study "Study missing after updating person"
 

--- a/tests/ArcCommander.Tests/Utils.fs
+++ b/tests/ArcCommander.Tests/Utils.fs
@@ -6,6 +6,8 @@ open System.IO
 open ARCtrl
 open ARCtrl.Spreadsheet
 open ArcCommander
+open ArcCommander.CLIArguments
+open ArcCommander.APIs
 open ArgumentProcessing
 open Argu
 
@@ -81,7 +83,19 @@ let processCommand (arcConfiguration : ArcConfiguration) (commandF : _ -> ArcPar
 
 let processCommandWoArgs (arcConfiguration : ArcConfiguration) commandF = commandF arcConfiguration
 
+let resetArc (arcConfiguration: ArcConfiguration) =
+    let testDir = arcConfiguration.General.["workdir"]
 
+    if Directory.Exists(testDir) then
+        Directory.Delete(testDir, true)
+
+let setupArc (arcConfiguration: ArcConfiguration) =
+    resetArc arcConfiguration
+
+    let arcArgs =
+        [ArcInitArgs.InvestigationIdentifier "TestInvestigation"]
+
+    processCommand arcConfiguration ArcAPI.init arcArgs
 module Result =
 
     let getMessage res =


### PR DESCRIPTION
- Adapted API changes introduced in ARCtrl 3.*
- Aligned FSharp.Core versions and updated low-risk dependencies
- Restored clean build on .NET 8
- Baseline for dotnet test remains: "Failed!  - Failed:    26, Passed:    20, Skipped:     1, Total:    47, Duration: 3 s - ArcCommander.Tests.dll (net8.0)"